### PR TITLE
[flink-5568] [Table API & SQL]Introduce interface for catalog, and provide an in-memory implementation, migrate current table registration to in-memory catalog

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableConfig.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableConfig.scala
@@ -20,7 +20,8 @@ package org.apache.flink.table.api
 import _root_.java.util.TimeZone
 
 import org.apache.flink.table.calcite.CalciteConfig
-
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.table.plan.catalog.{FlinkCatalog, InMemoryFlinkCatalog}
 /**
  * A config to define the runtime behavior of the Table API.
  */
@@ -40,6 +41,16 @@ class TableConfig {
     * Defines the configuration of Calcite for Table API and SQL queries.
     */
   private var calciteConfig = CalciteConfig.DEFAULT
+
+  /**
+    * Defines the name of flink internal catalog name
+    */
+  private var internalCatalogName = "__flink_internal_catalog__"
+
+  /**
+    * Defines the config of flink internal catalog name
+    */
+  private var internalCatalogConfig: Configuration = new Configuration()
 
   /**
    * Sets the timezone for date/time/timestamp conversions.
@@ -77,6 +88,38 @@ class TableConfig {
     */
   def setCalciteConfig(calciteConfig: CalciteConfig): Unit = {
     this.calciteConfig = calciteConfig
+  }
+
+  /**
+    * Returns the name of flink internal catalog name
+    *
+    * @return
+    */
+  def getInternalCatalogName = internalCatalogName
+
+  /**
+    * Sets the name of flink internal catalog name
+    *
+    * @param name
+    */
+  def setInternalCatalogName(name: String): Unit = {
+    this.internalCatalogName = name
+  }
+
+  /**
+    * Returns the config of flink internal catalog name
+    *
+    * @return
+    */
+  def getInternalCatalogConfig = internalCatalogConfig
+
+  /**
+    * Sets the config of flink internal catalog name
+    *
+    * @param config
+    */
+  def setInternalCatalogConfig(config: Configuration): Unit = {
+    this.internalCatalogConfig = config
   }
 }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/exceptions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/exceptions.scala
@@ -71,3 +71,61 @@ object ValidationException {
   * Exception for unwanted method calling on unresolved expression.
   */
 case class UnresolvedException(msg: String) extends RuntimeException(msg)
+
+/**
+  * Exception for operation on a nonexistent table
+  *
+  * @param tableIdentifier table identifier
+  * @param cause
+  */
+case class TableNotExistException(
+    tableIdentifier: String,
+    cause: Throwable)
+    extends RuntimeException(s"table ${tableIdentifier} does not exist!", cause) {
+
+  def this(tableIdentifier: String) = this(tableIdentifier, null)
+
+}
+
+/**
+  * Exception for adding an already existed table
+  *
+  * @param tableIdentifier table identifier
+  * @param cause
+  */
+case class TableAlreadyExistException(
+    tableIdentifier: String,
+    cause: Throwable)
+    extends RuntimeException(s"table ${tableIdentifier} already exists!", cause) {
+
+  def this(tableIdentifier: String) = this(tableIdentifier, null)
+
+}
+
+/**
+  * Exception for operation on a nonexistent database
+  *
+  * @param databaseIdentifier database identifier
+  * @param cause
+  */
+case class DatabaseNotExistException(
+    databaseIdentifier: String,
+    cause: Throwable)
+    extends RuntimeException(s"database ${databaseIdentifier} does not exist!", cause) {
+
+  def this(databaseIdentifier: String) = this(databaseIdentifier, null)
+}
+
+/**
+  * Exception for adding an already existed database
+  *
+  * @param databaseIdentifier database identifier
+  * @param cause
+  */
+case class DatabaseAlreadyExistException(
+    databaseIdentifier: String,
+    cause: Throwable)
+    extends RuntimeException(s"database ${databaseIdentifier} already exists!", cause) {
+
+  def this(databaseIdentifier: String) = this(databaseIdentifier, null)
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/catalog/CatalogDatabase.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/catalog/CatalogDatabase.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.catalog
+
+case class CatalogDatabase(dbName: String, properties: Map[String, String] = Map.empty)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/catalog/FlinkCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/catalog/FlinkCatalog.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.catalog
+
+import java.util.Set
+
+import org.apache.calcite.schema.Table
+import org.apache.flink.configuration.Configuration
+
+/**
+  * Interface for flink catalog.
+  */
+abstract class FlinkCatalog(conf: Configuration) {
+
+  /**
+    * Adds table information (including schema and statistics) into external Catalog
+    *
+    * @param dbName
+    * @param tableName
+    * @param table
+    * @param ignoreIfExists
+    */
+  def createTable(dbName: String, tableName: String, table: Table, ignoreIfExists: Boolean): Unit
+
+  /**
+    * Deletes table information (including schema and statistics) from external Catalog
+    *
+    * @param dbName
+    * @param tableName
+    * @param ignoreIfNotExists
+    */
+  def dropTable(dbName: String, tableName: String, ignoreIfNotExists: Boolean): Unit
+
+  /**
+    * Alters existed table information (including schema or statistics) into external Catalog
+    *
+    * @param dbName
+    * @param tableName
+    * @param table
+    */
+  def alterTable(dbName: String, tableName: String, table: Table): Unit
+
+  /**
+    * Adds or alters table information (including schema or statistics) into external Catalog
+    *
+    * @param dbName
+    * @param tableName
+    * @param table
+    * @return the previous table associated with dbName and tableName,
+    *         or null if there was no table mapping for dbName and tableName
+    */
+  def createOrUpdate(dbName: String, tableName: String, table: Table): Table
+
+  /**
+    * Gets table information from external Catalog, and rebuild table from these information
+    *
+    * @param dbName
+    * @param tableName
+    * @return
+    */
+  def getTable(dbName: String, tableName: String): Table
+
+  /**
+    * Gets the table name lists from current external Catalog
+    *
+    * @param dbName
+    * @return
+    */
+  def getTableNames(dbName: String): Set[String]
+
+  def getDatabase(dbName: String): CatalogDatabase
+
+  /**
+    * Gets the database name lists from current external Catalog
+    *
+    * @return
+    */
+  def getDatabaseNames(): Set[String]
+
+  /**
+    * Gets default database where retrieve table and add table
+    *
+    * @return the default database where retrieve table and add table;
+    *         or null if there is no default database
+    */
+  def getDefaultDatabase(): String
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/catalog/FlinkCatalogAbstractSchema.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/catalog/FlinkCatalogAbstractSchema.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.catalog
+
+import java.util.{Collection, Collections, Set}
+
+import org.apache.calcite.linq4j.tree.{DefaultExpression, Expression}
+import org.apache.calcite.schema.{Function, Schema, SchemaPlus, Table}
+
+import scala.collection.JavaConverters._
+
+abstract class FlinkCatalogAbstractSchema(
+    parentSchemaPlus: SchemaPlus,
+    schemaName: String,
+    flinkCatalog: FlinkCatalog) extends Schema {
+
+  // add current schema to parent schemaPlus as a sub-schema,
+  // returned the wrapped schema which is local root schema
+  protected val localRootSchemaPlus = parentSchemaPlus.add(schemaName, this)
+
+  registerSubSchemaToLocalRoot()
+
+  private val expression: Expression = new DefaultExpression(classOf[Any])
+
+  override def getSubSchema(name: String): Schema = null
+
+  override def getSubSchemaNames: Set[String] = Collections.emptySet[String]
+
+  override def getTable(name: String): Table = null
+
+  override def getTableNames: Set[String] = Collections.emptySet[String]
+
+  override def getFunctions(name: String): Collection[Function] =
+    Collections.emptyList[Function]
+
+  override def getFunctionNames: Set[String] = Collections.emptySet[String]
+
+  override def isMutable: Boolean = true
+
+  override def getExpression(parentSchema: SchemaPlus, name: String): Expression = expression
+
+  override def contentsHaveChangedSince(lastCheck: Long, now: Long): Boolean = true
+
+  /**
+    * Adds a table to current schema.
+    *
+    * @param name table name
+    * @param table
+    */
+  def add(name: String, table: Table): Option[Table] =
+    throw new UnsupportedOperationException(
+      s"Add table is not supported in schema $schemaName")
+
+  /**
+    * Drops a table from current schema.
+    *
+    * @param name table name
+    */
+  def dropTable(name: String): Unit =
+    throw new UnsupportedOperationException(
+      s"Drop table is not supported in schema $schemaName")
+
+  /**
+    * The schema can be a top level schema which doesn't have its own tables, but delivers
+    * to the default sub schemas for table look up. Default implementation returns itself.
+    *
+    * @return default schema where tables are created or retrieved from.
+    */
+  def getDefaultSchema(): Schema = this
+
+  /**
+    * Gets local root schema.
+    *
+    * @return
+    */
+  final def getLocalRootSchemaPlus: SchemaPlus = localRootSchemaPlus
+
+  /**
+    * Adds all sub-schema of current schema to local root schema as sub-schemas.
+    */
+  private def registerSubSchemaToLocalRoot(): Unit =
+    getSubSchemaNames.asScala.foreach(getSubSchema(_))
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/catalog/FlinkCatalogSchema.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/catalog/FlinkCatalogSchema.scala
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.catalog
+
+import java.util.Set
+
+import org.apache.calcite.jdbc.CalciteSchema
+import org.apache.calcite.schema.{Schema, SchemaPlus, Table}
+import org.apache.flink.configuration.Configuration
+
+/**
+  * Catalog schema implementation of Calcite Schema
+  *
+  * @param parentSchemaPlus parent schema plus
+  * @param schemaName       current schema name
+  * @param flinkCatalog     flink catalog
+  */
+class FlinkCatalogSchema(
+    parentSchemaPlus: SchemaPlus,
+    schemaName: String,
+    flinkCatalog: FlinkCatalog)
+    extends FlinkCatalogAbstractSchema(parentSchemaPlus, schemaName, flinkCatalog) {
+
+  private val defaultSubSchema: Option[FlinkCatalogDatabaseSchema] =
+    Option(flinkCatalog.getDefaultDatabase()).map(
+      new FlinkCatalogDatabaseSchema(getLocalRootSchemaPlus, _, flinkCatalog))
+
+  override def getSubSchema(name: String): Schema = {
+    val database = flinkCatalog.getDatabase(name)
+    if (database != null) {
+      new FlinkCatalogDatabaseSchema(getLocalRootSchemaPlus, name, flinkCatalog)
+    } else {
+      null
+    }
+  }
+
+  override def getSubSchemaNames: Set[String] = flinkCatalog.getDatabaseNames()
+
+  override def getTable(name: String): Table = defaultSubSchema match {
+    case Some(subSchema) => subSchema.getTable(name)
+    case None => super.getTable(name)
+  }
+
+  override def getTableNames: Set[String] = defaultSubSchema match {
+    case Some(subSchema) => subSchema.getTableNames
+    case None => super.getTableNames
+  }
+
+  /**
+    * Drops a table from default sub-schema if defined.
+    *
+    * @param name table name
+    */
+  override def dropTable(name: String): Unit = defaultSubSchema match {
+    case Some(subSchema) => {
+      subSchema.dropTable(name)
+      CalciteSchema.from(this.localRootSchemaPlus).tableMap.remove(name)
+    }
+    case None => super.dropTable(name)
+  }
+
+  /**
+    * Adds a table from default sub-schema if defined.
+    *
+    * @param name table name
+    * @param table
+    */
+  override def add(name: String, table: Table): Option[Table] = defaultSubSchema match {
+    case Some(subSchema) => {
+      val replacedTable = subSchema.add(name, table)
+      if(replacedTable.isDefined) {
+        CalciteSchema.from(this.localRootSchemaPlus).tableMap.remove(name)
+      }
+      replacedTable
+    }
+    case None => super.add(name, table)
+  }
+
+  override def getDefaultSchema(): Schema = defaultSubSchema match {
+    case Some(subSchema) => subSchema
+    case None => this
+  }
+
+  private class FlinkCatalogDatabaseSchema(
+      parentSchemaPlus: SchemaPlus,
+      dbName: String,
+      flinkCatalog: FlinkCatalog)
+      extends FlinkCatalogAbstractSchema(parentSchemaPlus, dbName, flinkCatalog) {
+
+    /**
+      * Returns a table with a given name, or null if not found.
+      *
+      * @param name Table name
+      * @return the table with the given name, or null if not found
+      */
+    override def getTable(name: String): Table = flinkCatalog.getTable(dbName, name)
+
+    /**
+      * Returns the names of the tables in this schema.
+      *
+      * @return names of the tables in this schema
+      */
+    override def getTableNames: Set[String] = flinkCatalog.getTableNames(dbName)
+
+    /**
+      * Drops a table from current schema.
+      *
+      * @param name table name
+      */
+    override def dropTable(name: String): Unit = {
+      flinkCatalog.dropTable(dbName, name, false)
+      CalciteSchema.from(this.localRootSchemaPlus).tableMap.remove(name)
+    }
+
+    /**
+      * Adds a table or Updates a table to current schema.
+      *
+      * @param name table name
+      * @param table
+      * @return replaced table
+      */
+    override def add(name: String, table: Table): Option[Table] = {
+      val replacedTable = flinkCatalog.createOrUpdate(dbName, name, table)
+      if (replacedTable != null) {
+        CalciteSchema.from(this.localRootSchemaPlus).tableMap.remove(name)
+      }
+      Option(replacedTable)
+    }
+  }
+
+}
+
+
+/**
+  * Factory for FlinkCatalogSchema objects.
+  */
+object FlinkCatalogSchema {
+
+  /**
+    * Creates a FlinkCatalogSchema.
+    *
+    * @param parentSchema Parent schema
+    * @param name         Name of this schema
+    * @param catalogClazz Catalog class
+    * @param catalogConf  Configuration of catalog
+    * @return Created schema
+    */
+  def create(
+      parentSchema: SchemaPlus,
+      name: String,
+      catalogClazz: Class[_ <: FlinkCatalog],
+      catalogConf: Configuration): FlinkCatalogSchema = {
+    val catalog = catalogClazz
+        .getConstructor(classOf[Configuration])
+        .newInstance(catalogConf)
+    new FlinkCatalogSchema(parentSchema, name, catalog)
+  }
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/catalog/InMemoryFlinkCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/catalog/InMemoryFlinkCatalog.scala
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.catalog
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.{Set, Map}
+
+import com.google.common.collect.ImmutableMap
+import org.apache.calcite.schema.Table
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.table.api.{TableAlreadyExistException, DatabaseNotExistException, TableNotExistException}
+
+/**
+  * An in-memory implementation of the table catalog.
+  *
+  */
+class InMemoryFlinkCatalog(conf: Configuration) extends FlinkCatalog(conf) {
+
+  private val defaultDatabase = "default"
+
+  // the map from database name to CatalogDatabase
+  private val databases: Map[String, CatalogDatabase] =
+    ImmutableMap.of(defaultDatabase, CatalogDatabase(defaultDatabase))
+
+  // the map from database names to its underlying tables
+  private val database2Table: Map[String, ConcurrentHashMap[String, Table]] =
+    ImmutableMap.of(defaultDatabase, new ConcurrentHashMap[String, Table]())
+
+  override def createTable(
+      dbName: String,
+      tableName: String,
+      table: Table,
+      ignoreIfExists: Boolean): Unit = {
+    val tables = getTables(dbName)
+    val oldTable = tables.putIfAbsent(tableName, table)
+    if (oldTable != null && !ignoreIfExists) {
+      throw new TableAlreadyExistException(tableName)
+    }
+  }
+
+  override def dropTable(dbName: String, tableName: String, ignoreIfNotExists: Boolean): Unit = {
+    val tables = getTables(dbName)
+    val deletedTable = tables.remove(tableName)
+    if (deletedTable == null && !ignoreIfNotExists) {
+      throw new TableNotExistException(tableName)
+    }
+  }
+
+  override def alterTable(dbName: String, tableName: String, table: Table): Unit = {
+    val tables = getTables(dbName)
+    val replacedTable = tables.replace(tableName, table)
+    if (replacedTable == null) {
+      throw new TableNotExistException(tableName)
+    }
+  }
+
+  override def createOrUpdate(dbName: String, tableName: String, table: Table): Table = {
+    val tables = getTables(dbName)
+    tables.put(tableName, table)
+  }
+
+  override def getTable(dbName: String, tableName: String): Table = {
+    val tables = getTables(dbName)
+    val table = tables.get(tableName)
+    if (table == null) {
+      throw new TableNotExistException(tableName)
+    }
+    table
+  }
+
+  override def getTableNames(dbName: String): Set[String] = {
+    val tables = getTables(dbName)
+    tables.keySet()
+  }
+
+  override def getDatabaseNames(): Set[String] = databases.keySet
+
+  override def getDatabase(dbName: String): CatalogDatabase = {
+    databases.get(dbName)
+  }
+
+  /**
+    * Gets default database where retrieve table and add table
+    *
+    * @return
+    */
+  override def getDefaultDatabase(): String = defaultDatabase
+
+  /**
+    * Gets all tables underlying a database
+    *
+    * @param dbName database name
+    * @return all tables underlying a database
+    */
+  private def getTables(dbName: String): ConcurrentHashMap[String, Table] = {
+    val tables = database2Table.get(dbName)
+    if (tables == null) {
+      throw new DatabaseNotExistException(dbName)
+    }
+    tables
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/TableSourceTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/TableSourceTest.scala
@@ -200,10 +200,12 @@ class TableSourceTest extends TableTestBase {
   }
 
   def sourceBatchTableNode(sourceName: String, fields: Array[String]): String = {
-    s"BatchTableSourceScan(table=[[$sourceName]], fields=[${fields.mkString(", ")}])"
+    s"BatchTableSourceScan(table=[[__flink_internal_catalog__, $sourceName]], " +
+        s"fields=[${fields.mkString(", ")}])"
   }
 
   def sourceStreamTableNode(sourceName: String, fields: Array[String] ): String = {
-    s"StreamTableSourceScan(table=[[$sourceName]], fields=[${fields.mkString(", ")}])"
+    s"StreamTableSourceScan(table=[[__flink_internal_catalog__, $sourceName]], " +
+        s"fields=[${fields.mkString(", ")}])"
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/catalog/FlinkCatalogSchemaTestOnInMemCatalog.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/catalog/FlinkCatalogSchemaTestOnInMemCatalog.scala
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.catalog
+
+import java.util.Collections
+
+import com.google.common.collect.Lists
+import org.apache.calcite.jdbc.CalciteSchema
+import org.apache.calcite.prepare.CalciteCatalogReader
+import org.apache.calcite.schema.{SchemaPlus, Table}
+import org.apache.calcite.sql.validate.{SqlMoniker, SqlMonikerType}
+import org.apache.calcite.tools.Frameworks
+import org.apache.commons.collections.CollectionUtils
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.table.calcite.{FlinkTypeFactory, FlinkTypeSystem}
+import org.apache.flink.table.plan.schema.{FlinkTable, TableSourceTable}
+import org.apache.flink.table.utils.CommonTestData
+import org.junit.{Assert, Before, Test}
+
+import scala.collection.JavaConverters._
+
+class FlinkCatalogSchemaTestOnInMemCatalog {
+
+  private val schemaName = "test"
+  private var flinkCatalogSchema: FlinkCatalogSchema = _
+  private var calciteCatalogReader: CalciteCatalogReader = _
+
+  @Before
+  def setUp: Unit = {
+    val rootSchemaPlus: SchemaPlus = Frameworks.createRootSchema(true)
+    val catalog = new InMemoryFlinkCatalog(new Configuration)
+    flinkCatalogSchema = new FlinkCatalogSchema(rootSchemaPlus, schemaName, catalog)
+    val typeFactory = new FlinkTypeFactory(new FlinkTypeSystem())
+    calciteCatalogReader = new CalciteCatalogReader(
+      CalciteSchema.from(rootSchemaPlus),
+      false,
+      Collections.emptyList(),
+      typeFactory)
+  }
+
+  @Test
+  def testGetSubSchema(): Unit = {
+    val allSchemaObjectNames = calciteCatalogReader
+        .getAllSchemaObjectNames(Lists.newArrayList(schemaName))
+    Assert.assertTrue(allSchemaObjectNames.size() == 1)
+    Assert.assertEquals(SqlMonikerType.SCHEMA, allSchemaObjectNames.get(0).getType)
+    Assert.assertTrue(
+      CollectionUtils.isEqualCollection(
+        allSchemaObjectNames.get(0).getFullyQualifiedNames,
+        Lists.newArrayList(schemaName, "default")
+      ))
+  }
+
+  @Test
+  def testAddTable(): Unit = {
+    Assert.assertNull(calciteCatalogReader.getTable(Lists.newArrayList(schemaName, "t1")))
+    flinkCatalogSchema.add("t1", createTableInstance())
+    Assert.assertNotNull(calciteCatalogReader.getTable(Lists.newArrayList(schemaName, "t1")))
+  }
+
+  @Test
+  def testGetTable(): Unit = {
+    val table = createTableInstance()
+    flinkCatalogSchema.add("t1", table)
+    val wrappedTable = calciteCatalogReader.getTable(Lists.newArrayList(schemaName, "t1"))
+    wrappedTable.unwrap(classOf[FlinkTable[_]]) match {
+      case t: FlinkTable[_] =>
+        Assert.assertEquals(table, t)
+      case _ =>
+        Assert.fail("table is not expected")
+    }
+  }
+
+  @Test
+  def testGetTableNames(): Unit = {
+    Assert.assertEquals(getTableObjectNames.length, 0)
+
+    flinkCatalogSchema.add("t1", createTableInstance())
+    flinkCatalogSchema.add("t2", createTableInstance())
+    val tableNames = getTableObjectNames
+    Assert.assertEquals(tableNames.length, 2)
+    Assert.assertEquals(
+      Lists.newArrayList(schemaName, "t1"),
+      tableNames(0).getFullyQualifiedNames)
+    Assert.assertEquals(
+      Lists.newArrayList(schemaName, "t2"),
+      tableNames(1).getFullyQualifiedNames)
+  }
+
+  @Test
+  def testDropTable(): Unit = {
+    flinkCatalogSchema.add("t1", createTableInstance())
+    Assert.assertNotNull(calciteCatalogReader.getTable(Lists.newArrayList(schemaName, "t1")))
+    flinkCatalogSchema.dropTable("t1")
+    Assert.assertNull(calciteCatalogReader.getTable(Lists.newArrayList(schemaName, "t1")))
+  }
+
+  @Test
+  def testAlterTable(): Unit = {
+    val originTable = createTableInstance()
+    flinkCatalogSchema.add("t1", originTable)
+    calciteCatalogReader.getTable(Lists.newArrayList(schemaName, "t1"))
+        .unwrap(classOf[FlinkTable[_]]) match {
+      case t: FlinkTable[_] =>
+        Assert.assertEquals(originTable, t)
+      case _ =>
+        Assert.fail("table is not expected")
+    }
+    val newTable = createTableInstance()
+    flinkCatalogSchema.add("t1", newTable)
+    calciteCatalogReader.getTable(Lists.newArrayList(schemaName, "t1"))
+        .unwrap(classOf[FlinkTable[_]]) match {
+      case t: FlinkTable[_] =>
+        Assert.assertNotEquals(originTable, t)
+        Assert.assertEquals(newTable, t)
+      case _ =>
+        Assert.fail("table is not expected")
+    }
+  }
+
+  private def createTableInstance(): Table = {
+    val csvTableSource = CommonTestData.getCsvTableSource
+    new TableSourceTable(csvTableSource)
+  }
+
+  private def getTableObjectNames: Seq[SqlMoniker] = {
+    calciteCatalogReader
+        .getAllSchemaObjectNames(Lists.newArrayList(schemaName))
+        .asScala
+        .filter(_.getType == SqlMonikerType.TABLE)
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/catalog/InMemoryFlinkCatalogTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/catalog/InMemoryFlinkCatalogTest.scala
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.catalog
+
+import org.apache.flink.configuration.Configuration
+import org.apache.calcite.schema.Table
+import org.apache.flink.table.api.{DatabaseNotExistException, TableAlreadyExistException, TableNotExistException}
+import org.apache.flink.table.plan.schema.TableSourceTable
+import org.apache.flink.table.utils.CommonTestData
+import org.junit.{Assert, Before, Test}
+import org.powermock.reflect.Whitebox
+import scala.collection.JavaConverters._
+
+class InMemoryFlinkCatalogTest {
+
+  private val databaseName = "default"
+  private var catalog: FlinkCatalog = _
+
+  @Before
+  def setUp: Unit = {
+    catalog = new InMemoryFlinkCatalog(new Configuration)
+  }
+
+  @Test
+  def testCreateTable(): Unit = {
+    Assert.assertTrue(catalog.getTableNames(databaseName).isEmpty)
+    catalog.createTable(databaseName, "t1", createTableInstance(), false)
+    Assert.assertTrue(catalog.getTableNames(databaseName).asScala == Set("t1"))
+  }
+
+  @Test(expected = classOf[TableAlreadyExistException])
+  def testCreateExistedTable(): Unit = {
+    val tableName = "t1"
+    Whitebox.setInternalState(catalog, "")
+    catalog.createTable(databaseName, tableName, createTableInstance(), false)
+    catalog.createTable(databaseName, tableName, createTableInstance(), false)
+  }
+
+  @Test
+  def testGetTable(): Unit = {
+    val table = createTableInstance()
+    catalog.createTable(databaseName, "t1", table, false)
+    Assert.assertEquals(catalog.getTable(databaseName, "t1"), table)
+  }
+
+  @Test(expected = classOf[DatabaseNotExistException])
+  def testGetTableUnderNotExistDatabaseName(): Unit = {
+    catalog.getTable("notexistedDb", "t1")
+  }
+
+  @Test(expected = classOf[TableNotExistException])
+  def testGetNotExistTable(): Unit = {
+    catalog.getTable(databaseName, "t1")
+  }
+
+  @Test
+  def testAlterTable(): Unit = {
+    val tableName = "t1"
+    val table = createTableInstance()
+    catalog.createTable(databaseName, tableName, table, false)
+    Assert.assertEquals(catalog.getTable(databaseName, tableName), table)
+    val newTable = createTableInstance()
+    catalog.alterTable(databaseName, tableName, newTable)
+    val currentTable = catalog.getTable(databaseName, tableName)
+    // validate the table is really replaced after alter table
+    Assert.assertNotEquals(table, currentTable)
+    Assert.assertEquals(newTable, currentTable)
+  }
+
+  @Test(expected = classOf[TableNotExistException])
+  def testAlterNotExistTable(): Unit = {
+    catalog.alterTable(databaseName, "t1", createTableInstance())
+  }
+
+  @Test
+  def testDropTable(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(databaseName, tableName, createTableInstance(), false)
+    Assert.assertTrue(catalog.getTableNames(databaseName).contains(tableName))
+    catalog.dropTable(databaseName, tableName, false)
+    Assert.assertFalse(catalog.getTableNames(databaseName).contains(tableName))
+  }
+
+  @Test(expected = classOf[TableNotExistException])
+  def testDropNotExistTable(): Unit = {
+    catalog.dropTable(databaseName, "t1", false)
+  }
+
+  @Test
+  def testGetDatabaseNames(): Unit = {
+    Assert.assertTrue(catalog.getDatabaseNames().asScala == Set("default"))
+  }
+
+  @Test
+  def testGetDatabase(): Unit = {
+    Assert.assertNotNull(catalog.getDatabase(databaseName))
+  }
+
+  @Test
+  def testGetNotExistDatabase(): Unit = {
+    Assert.assertNull(catalog.getDatabase("notexistedDb"))
+  }
+
+  @Test
+  def testGetDefaultDatabase(): Unit = {
+    Assert.assertEquals(catalog.getDefaultDatabase(), databaseName)
+  }
+
+  private def createTableInstance(): Table = {
+    val csvTableSource = CommonTestData.getCsvTableSource
+    new TableSourceTable(csvTableSource)
+  }
+
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/rules/NormalizationRulesTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/rules/NormalizationRulesTest.scala
@@ -50,7 +50,7 @@ class NormalizationRulesTest extends TableTestBase {
       unaryNode("LogicalAggregate",
         unaryNode("LogicalAggregate",
           unaryNode("LogicalProject",
-            values("LogicalTableScan", term("table", "[MyTable]")),
+            values("LogicalTableScan", term("table", "[__flink_internal_catalog__, MyTable]")),
             term("b", "$1"), term("a", "$0")),
           term("group", "{0, 1}")),
         term("group", "{0}"), term("EXPR$0", "COUNT($1)")
@@ -84,7 +84,7 @@ class NormalizationRulesTest extends TableTestBase {
       unaryNode("LogicalAggregate",
         unaryNode("LogicalAggregate",
           unaryNode("LogicalProject",
-            values("LogicalTableScan", term("table", "[MyTable]")),
+            values("LogicalTableScan", term("table", "[__flink_internal_catalog__, MyTable]")),
             term("b", "$1"), term("a", "$0")),
           term("group", "{0, 1}")),
         term("group", "{0}"), term("EXPR$0", "COUNT($1)")

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
@@ -105,11 +105,11 @@ object TableTestUtil {
   }
 
   def batchTableNode(idx: Int): String = {
-    s"DataSetScan(table=[[_DataSetTable_$idx]])"
+    s"DataSetScan(table=[[__flink_internal_catalog__, _DataSetTable_$idx]])"
   }
 
   def streamTableNode(idx: Int): String = {
-    s"DataStreamScan(table=[[_DataStreamTable_$idx]])"
+    s"DataStreamScan(table=[[__flink_internal_catalog__, _DataStreamTable_$idx]])"
   }
 
 }

--- a/flink-libraries/flink-table/src/test/scala/resources/testFilter0.out
+++ b/flink-libraries/flink-table/src/test/scala/resources/testFilter0.out
@@ -1,10 +1,10 @@
 == Abstract Syntax Tree ==
 LogicalFilter(condition=[=(MOD($0, 2), 0)])
-  LogicalTableScan(table=[[_DataSetTable_0]])
+  LogicalTableScan(table=[[__flink_internal_catalog__, _DataSetTable_0]])
 
 == Optimized Logical Plan ==
 DataSetCalc(select=[a, b], where=[=(MOD(a, 2), 0)])
-  DataSetScan(table=[[_DataSetTable_0]])
+  DataSetScan(table=[[__flink_internal_catalog__, _DataSetTable_0]])
 
 == Physical Execution Plan ==
 Stage 3 : Data Source

--- a/flink-libraries/flink-table/src/test/scala/resources/testFilter1.out
+++ b/flink-libraries/flink-table/src/test/scala/resources/testFilter1.out
@@ -1,10 +1,10 @@
 == Abstract Syntax Tree ==
 LogicalFilter(condition=[=(MOD($0, 2), 0)])
-  LogicalTableScan(table=[[_DataSetTable_0]])
+  LogicalTableScan(table=[[__flink_internal_catalog__, _DataSetTable_0]])
 
 == Optimized Logical Plan ==
 DataSetCalc(select=[a, b], where=[=(MOD(a, 2), 0)])
-  DataSetScan(table=[[_DataSetTable_0]])
+  DataSetScan(table=[[__flink_internal_catalog__, _DataSetTable_0]])
 
 == Physical Execution Plan ==
 Stage 3 : Data Source

--- a/flink-libraries/flink-table/src/test/scala/resources/testFilterStream0.out
+++ b/flink-libraries/flink-table/src/test/scala/resources/testFilterStream0.out
@@ -1,10 +1,10 @@
 == Abstract Syntax Tree ==
 LogicalFilter(condition=[=(MOD($0, 2), 0)])
-  LogicalTableScan(table=[[_DataStreamTable_0]])
+  LogicalTableScan(table=[[__flink_internal_catalog__, _DataStreamTable_0]])
 
 == Optimized Logical Plan ==
 DataStreamCalc(select=[a, b], where=[=(MOD(a, 2), 0)])
-  DataStreamScan(table=[[_DataStreamTable_0]])
+  DataStreamScan(table=[[__flink_internal_catalog__, _DataStreamTable_0]])
 
 == Physical Execution Plan ==
 Stage 1 : Data Source

--- a/flink-libraries/flink-table/src/test/scala/resources/testJoin0.out
+++ b/flink-libraries/flink-table/src/test/scala/resources/testJoin0.out
@@ -2,14 +2,14 @@
 LogicalProject(a=[$0], c=[$2])
   LogicalFilter(condition=[=($1, $3)])
     LogicalJoin(condition=[true], joinType=[inner])
-      LogicalTableScan(table=[[_DataSetTable_0]])
-      LogicalTableScan(table=[[_DataSetTable_1]])
+      LogicalTableScan(table=[[__flink_internal_catalog__, _DataSetTable_0]])
+      LogicalTableScan(table=[[__flink_internal_catalog__, _DataSetTable_1]])
 
 == Optimized Logical Plan ==
 DataSetCalc(select=[a, c])
   DataSetJoin(where=[=(b, d)], join=[a, b, c, d], joinType=[InnerJoin])
-    DataSetScan(table=[[_DataSetTable_0]])
-    DataSetScan(table=[[_DataSetTable_1]])
+    DataSetScan(table=[[__flink_internal_catalog__, _DataSetTable_0]])
+    DataSetScan(table=[[__flink_internal_catalog__, _DataSetTable_1]])
 
 == Physical Execution Plan ==
 Stage 4 : Data Source

--- a/flink-libraries/flink-table/src/test/scala/resources/testJoin1.out
+++ b/flink-libraries/flink-table/src/test/scala/resources/testJoin1.out
@@ -2,14 +2,14 @@
 LogicalProject(a=[$0], c=[$2])
   LogicalFilter(condition=[=($1, $3)])
     LogicalJoin(condition=[true], joinType=[inner])
-      LogicalTableScan(table=[[_DataSetTable_0]])
-      LogicalTableScan(table=[[_DataSetTable_1]])
+      LogicalTableScan(table=[[__flink_internal_catalog__, _DataSetTable_0]])
+      LogicalTableScan(table=[[__flink_internal_catalog__, _DataSetTable_1]])
 
 == Optimized Logical Plan ==
 DataSetCalc(select=[a, c])
   DataSetJoin(where=[=(b, d)], join=[a, b, c, d], joinType=[InnerJoin])
-    DataSetScan(table=[[_DataSetTable_0]])
-    DataSetScan(table=[[_DataSetTable_1]])
+    DataSetScan(table=[[__flink_internal_catalog__, _DataSetTable_0]])
+    DataSetScan(table=[[__flink_internal_catalog__, _DataSetTable_1]])
 
 == Physical Execution Plan ==
 Stage 4 : Data Source

--- a/flink-libraries/flink-table/src/test/scala/resources/testUnion0.out
+++ b/flink-libraries/flink-table/src/test/scala/resources/testUnion0.out
@@ -1,12 +1,12 @@
 == Abstract Syntax Tree ==
 LogicalUnion(all=[true])
-  LogicalTableScan(table=[[_DataSetTable_0]])
-  LogicalTableScan(table=[[_DataSetTable_1]])
+  LogicalTableScan(table=[[__flink_internal_catalog__, _DataSetTable_0]])
+  LogicalTableScan(table=[[__flink_internal_catalog__, _DataSetTable_1]])
 
 == Optimized Logical Plan ==
 DataSetUnion(union=[count, word])
-  DataSetScan(table=[[_DataSetTable_0]])
-  DataSetScan(table=[[_DataSetTable_1]])
+  DataSetScan(table=[[__flink_internal_catalog__, _DataSetTable_0]])
+  DataSetScan(table=[[__flink_internal_catalog__, _DataSetTable_1]])
 
 == Physical Execution Plan ==
 Stage 3 : Data Source

--- a/flink-libraries/flink-table/src/test/scala/resources/testUnion1.out
+++ b/flink-libraries/flink-table/src/test/scala/resources/testUnion1.out
@@ -1,12 +1,12 @@
 == Abstract Syntax Tree ==
 LogicalUnion(all=[true])
-  LogicalTableScan(table=[[_DataSetTable_0]])
-  LogicalTableScan(table=[[_DataSetTable_1]])
+  LogicalTableScan(table=[[__flink_internal_catalog__, _DataSetTable_0]])
+  LogicalTableScan(table=[[__flink_internal_catalog__, _DataSetTable_1]])
 
 == Optimized Logical Plan ==
 DataSetUnion(union=[count, word])
-  DataSetScan(table=[[_DataSetTable_0]])
-  DataSetScan(table=[[_DataSetTable_1]])
+  DataSetScan(table=[[__flink_internal_catalog__, _DataSetTable_0]])
+  DataSetScan(table=[[__flink_internal_catalog__, _DataSetTable_1]])
 
 == Physical Execution Plan ==
 Stage 3 : Data Source

--- a/flink-libraries/flink-table/src/test/scala/resources/testUnionStream0.out
+++ b/flink-libraries/flink-table/src/test/scala/resources/testUnionStream0.out
@@ -1,12 +1,12 @@
 == Abstract Syntax Tree ==
 LogicalUnion(all=[true])
-  LogicalTableScan(table=[[_DataStreamTable_0]])
-  LogicalTableScan(table=[[_DataStreamTable_1]])
+  LogicalTableScan(table=[[__flink_internal_catalog__, _DataStreamTable_0]])
+  LogicalTableScan(table=[[__flink_internal_catalog__, _DataStreamTable_1]])
 
 == Optimized Logical Plan ==
 DataStreamUnion(union=[count, word])
-  DataStreamScan(table=[[_DataStreamTable_0]])
-  DataStreamScan(table=[[_DataStreamTable_1]])
+  DataStreamScan(table=[[__flink_internal_catalog__, _DataStreamTable_0]])
+  DataStreamScan(table=[[__flink_internal_catalog__, _DataStreamTable_1]])
 
 == Physical Execution Plan ==
 Stage 1 : Data Source


### PR DESCRIPTION
This pr aims to Introduce interface for catalog, and provide an in-memory implementation, finally migrate current table registration to in-memory catalog.
The main change including:
1) Introduce FlinkCatalog interface
2) Provide an in-memory implementation(one-level)
3) Introduce FlinkCatalogSchema which is an implementation of Calcite Schema interface. It registers subSchemas/tables/functions to Calcite framework for validation and parse.
4) Migrate current table registration to a FlinkCatalogSchema which based on in-memory catalog implementation
5) Modify previous UT to adapt the changes.