### PR TITLE
给ExternalCatalog增加partition的概念

### DIFF
--- a/flink-libraries/flink-table/pom.xml
+++ b/flink-libraries/flink-table/pom.xml
@@ -92,7 +92,12 @@ under the License.
 			</exclusions>
 		</dependency>
 
-
+		<dependency>
+			<groupId>org.reflections</groupId>
+			<artifactId>reflections</artifactId>
+			<version>0.9.10</version>
+			<scope>compile</scope>
+		</dependency>
 		<!-- test dependencies -->
 
 		<dependency>

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/annotation/ExternalCatalogCompatible.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/annotation/ExternalCatalogCompatible.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.annotation;
+
+import org.apache.flink.annotation.Public;
+import org.apache.flink.table.catalog.TableSourceConverter;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A tableSource with this annotation represents it is compatible with external catalog, that is,
+ * an instance of this tableSource can be converted to or converted from external catalog table
+ * instance.
+ * The annotation contains the following information:
+ * <ul>
+ * <li> external catalog table type name for this kind of tableSource </li>
+ * <li> external catalog table <-> tableSource converter class </li>
+ * </ul>
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Public
+public @interface ExternalCatalogCompatible {
+
+	/**
+	 * Specifies the external catalog table type of this kind of tableSource.
+	 * e.g tableType of CsvTableSource can be csv, the tableType of HBaseTableSource can be hbase.
+	 *
+	 * @return the external catalog table type of this kind of tableSource.
+	 */
+	String tableType();
+
+	/**
+	 * Specifies the converter class for this kind of tableSource
+	 * which is used to convert {@link org.apache.flink.table.catalog.ExternalCatalogTable} to
+	 * or from {@link org.apache.flink.table.sources.TableSource}
+	 *
+	 * @return the converter class for this kind of tableSource.
+	 */
+	Class<? extends TableSourceConverter<?>> converter();
+
+}

--- a/flink-libraries/flink-table/src/main/resources/externalcatalogTable.properties
+++ b/flink-libraries/flink-table/src/main/resources/externalcatalogTable.properties
@@ -1,0 +1,19 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+scan.package=org.apache.flink.table.sources

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/exceptions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/exceptions.scala
@@ -71,3 +71,93 @@ object ValidationException {
   * Exception for unwanted method calling on unresolved expression.
   */
 case class UnresolvedException(msg: String) extends RuntimeException(msg)
+
+/**
+  * Exception for operation on a nonexistent table
+  *
+  * @param db    database name
+  * @param table table name
+  * @param cause
+  */
+case class TableNotExistException(
+    db: String,
+    table: String,
+    cause: Throwable)
+    extends RuntimeException(s"table $db.$table does not exist!", cause) {
+
+  def this(db: String, table: String) = this(db, table, null)
+
+}
+
+/**
+  * Exception for adding an already existed table
+  *
+  * @param db    database name
+  * @param table table name
+  * @param cause
+  */
+case class TableAlreadyExistException(
+    db: String,
+    table: String,
+    cause: Throwable)
+    extends RuntimeException(s"table $db.$table already exists!", cause) {
+
+  def this(db: String, table: String) = this(db, table, null)
+
+}
+
+/**
+  * Exception for operation on a nonexistent database
+  *
+  * @param db database name
+  * @param cause
+  */
+case class DatabaseNotExistException(
+    db: String,
+    cause: Throwable)
+    extends RuntimeException(s"database $db does not exist!", cause) {
+
+  def this(db: String) = this(db, null)
+}
+
+/**
+  * Exception for adding an already existed database
+  *
+  * @param db database name
+  * @param cause
+  */
+case class DatabaseAlreadyExistException(
+    db: String,
+    cause: Throwable)
+    extends RuntimeException(s"database $db already exists!", cause) {
+
+  def this(db: String) = this(db, null)
+}
+
+/**
+  * Exception for operation on a nonexistent external catalog table type
+  *
+  * @param tableType external catalog table type
+  * @param cause
+  */
+case class ExternalCatalogTableTypeNotExistException(
+    tableType: String,
+    cause: Throwable)
+    extends RuntimeException(s"external catalog table type $tableType does not exist!", cause) {
+
+  def this(tableType: String) = this(tableType, null)
+}
+
+/**
+  * Exception for adding an already existed external catalog
+  *
+  * @param tableType external catalog table type
+  * @param cause
+  */
+case class ExternalCatalogTableTypeAlreadyExistException(
+    tableType: String,
+    cause: Throwable)
+    extends RuntimeException(s"external catalog table type $tableType already exists!", cause) {
+
+  def this(tableType: String) = this(tableType, null)
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/exceptions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/exceptions.scala
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.api
 
+import org.apache.flink.table.catalog.ExternalCatalogTypes.PartitionSpec
+
 /**
   * Exception for all errors occurring during expression parsing.
   */
@@ -71,6 +73,48 @@ object ValidationException {
   * Exception for unwanted method calling on unresolved expression.
   */
 case class UnresolvedException(msg: String) extends RuntimeException(msg)
+
+/**
+  * Exception for operation on a nonexistent partition
+  *
+  * @param db            database name
+  * @param table         table name
+  * @param partitionSpec partition spec
+  * @param cause
+  */
+case class PartitionNotExistException(
+    db: String,
+    table: String,
+    partitionSpec: PartitionSpec,
+    cause: Throwable)
+    extends RuntimeException(
+      s"partition $partitionSpec does not exist in table $db.$table!", cause) {
+
+  def this(db: String, table: String, partitionSpec: PartitionSpec) =
+    this(db, table, partitionSpec, null)
+
+}
+
+/**
+  * Exception for adding an already existed partition
+  *
+  * @param db            database name
+  * @param table         table name
+  * @param partitionSpec partition spec
+  * @param cause
+  */
+case class PartitionAlreadyExistException(
+    db: String,
+    table: String,
+    partitionSpec: PartitionSpec,
+    cause: Throwable)
+    extends RuntimeException(
+      s"partition [${partitionSpec.mkString(", ")}] already exists in table $db.$table!", cause) {
+
+  def this(db: String, table: String, partitionSpec: PartitionSpec) =
+    this(db, table, partitionSpec, null)
+
+}
 
 /**
   * Exception for operation on a nonexistent table

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/CatalogTableHelper.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/CatalogTableHelper.scala
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+import java.io.IOException
+import java.lang.reflect.Modifier
+import java.net.URL
+import java.util.Properties
+
+import org.apache.flink.table.annotation.ExternalCatalogCompatible
+import org.apache.flink.table.api.{ExternalCatalogTableTypeAlreadyExistException, ExternalCatalogTableTypeNotExistException}
+import org.apache.flink.table.plan.schema.TableSourceTable
+import org.apache.flink.table.plan.stats.FlinkStatistic
+import org.apache.flink.table.sources.TableSource
+import org.apache.flink.util.InstantiationUtil
+import org.reflections.Reflections
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.HashMap
+
+/**
+  * The utility class is used to convert ExternalCatalogTable to TableSourceTable.
+  */
+object CatalogTableHelper {
+
+  // config file to specifier the scan package to search tableSources
+  // which is compatible with external catalog.
+  private val tableSourceConfigFileName = "externalcatalogTable.properties"
+
+  private val LOG: Logger = LoggerFactory.getLogger(this.getClass)
+
+  // registered tableSources which are compatible with external catalog.
+  // Key is table type name, Value is converter class.
+  private val tableSourceTypeToConvertersClazz = {
+    val registeredConverters =
+      new HashMap[String, Class[_ <: TableSourceConverter[_]]]
+    // scan all config file to find all tableSources which are compatible with external catalog.
+    val resourceUrls = getClass.getClassLoader.getResources(tableSourceConfigFileName)
+    while (resourceUrls.hasMoreElements) {
+      val url = resourceUrls.nextElement()
+      parseScanPackageFromConfigFile(url) match {
+        case Some(scanPackage) =>
+          val clazzWithAnnotations = new Reflections(scanPackage)
+              .getTypesAnnotatedWith(classOf[ExternalCatalogCompatible])
+          clazzWithAnnotations.asScala.foreach(clazz =>
+            if (classOf[TableSource[_]].isAssignableFrom(clazz)) {
+              if (Modifier.isAbstract(clazz.getModifiers()) ||
+                  Modifier.isInterface(clazz.getModifiers)) {
+                LOG.warn(
+                  s"class :[${clazz.getName}] is also with ExternalCatalogCompatible annotation, " +
+                      s"but it's an abstract clazz or an interface.")
+              } else {
+                val externalCatalogCompatible: ExternalCatalogCompatible =
+                  clazz.getAnnotation(classOf[ExternalCatalogCompatible])
+                val tableSourceName = externalCatalogCompatible.tableType()
+                if (registeredConverters.contains(tableSourceName)) {
+                  LOG.error(s"The table type [$tableSourceName] is already registered.")
+                  throw new ExternalCatalogTableTypeAlreadyExistException(tableSourceName)
+                }
+                registeredConverters.put(tableSourceName, externalCatalogCompatible.converter())
+              }
+            } else {
+              LOG.warn(
+                s"class :[${clazz.getName}] is also with ExternalCatalogCompatible annotation, " +
+                    s"but it's not sub-class of tableSource.")
+            }
+          )
+        case None =>
+      }
+    }
+    registeredConverters
+  }
+
+  /**
+    * Converts an [[ExternalCatalogTable]] instance to a [[TableSourceTable]] instance
+    *
+    * @param externalCatalogTable the [[ExternalCatalogTable]] instance which to convert
+    * @return converted [[TableSourceTable]] instance from the input catalog table
+    */
+  def fromExternalCatalogTable(externalCatalogTable: ExternalCatalogTable): TableSourceTable[_] = {
+    val tableType = externalCatalogTable.tableType
+    tableSourceTypeToConvertersClazz.get(tableType) match {
+      case Some(converterClazz) =>
+        val converter = InstantiationUtil.instantiate(converterClazz)
+        val convertedTableSource: TableSource[_] =
+          converter.fromExternalCatalogTable(externalCatalogTable) match {
+            case ts: TableSource[_] => ts
+            case _ => throw new RuntimeException(
+              s"the converted result from converter ${converterClazz.getName} " +
+                  s"is not tableSource instance")
+          }
+
+        val flinkStatistic = externalCatalogTable.stats match {
+          case Some(stats) => FlinkStatistic.of(stats)
+          case None => FlinkStatistic.UNKNOWN
+        }
+        new TableSourceTable(convertedTableSource, flinkStatistic)
+      case None =>
+        LOG.error(s"the table type [$tableType] does not exist.")
+        throw new ExternalCatalogTableTypeNotExistException(tableType)
+    }
+  }
+
+  private def parseScanPackageFromConfigFile(url: URL): Option[String] = {
+    val properties = new Properties()
+    try {
+      properties.load(url.openStream())
+      val scanPackage = properties.getProperty("scan.package")
+      if (scanPackage == null || scanPackage.isEmpty) {
+        LOG.warn(s"config file $url does not contain scan package!")
+        None
+      } else {
+        Some(scanPackage)
+      }
+    } catch {
+      case e: IOException =>
+        LOG.warn(s"fail to open config file [$url]", e)
+        None
+    }
+  }
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalog.scala
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+/**
+  * This class is responsible for interact with external catalog.
+  * Its main responsibilities including:
+  * <ul>
+  * <li> create/drop/alter database or tables for DDL operations
+  * <li> provide tables for calcite catalog, it looks up databases or tables in the external catalog
+  * </ul>
+  */
+trait ExternalCatalog {
+
+  /**
+    * Adds table into external Catalog
+    *
+    * @param table          description of table which to create
+    * @param ignoreIfExists whether to ignore operation if table already exists
+    */
+  def createTable(table: ExternalCatalogTable, ignoreIfExists: Boolean): Unit
+
+  /**
+    * Deletes table from external Catalog
+    *
+    * @param dbName            database name
+    * @param tableName         table name
+    * @param ignoreIfNotExists whether to ignore operation if table not exist yet
+    */
+  def dropTable(dbName: String, tableName: String, ignoreIfNotExists: Boolean): Unit
+
+  /**
+    * Alters existed table into external Catalog
+    *
+    * @param table description of table which to alter
+    */
+  def alterTable(table: ExternalCatalogTable): Unit
+
+  /**
+    * Gets table from external Catalog
+    *
+    * @param dbName    database name
+    * @param tableName table name
+    * @return table
+    */
+  def getTable(dbName: String, tableName: String): ExternalCatalogTable
+
+  /**
+    * Gets the table name lists from current external Catalog
+    *
+    * @param dbName database name
+    * @return lists of table name
+    */
+  def listTables(dbName: String): Seq[String]
+
+  /**
+    * Adds database into external Catalog
+    *
+    * @param db             database name
+    * @param ignoreIfExists whether to ignore operation if database already exists
+    */
+  def createDatabase(db: ExternalCatalogDatabase, ignoreIfExists: Boolean): Unit
+
+  /**
+    * Deletes database from external Catalog
+    *
+    * @param dbName            database name
+    * @param ignoreIfNotExists whether to ignore operation if table not exist yet
+    */
+  def dropDatabase(dbName: String, ignoreIfNotExists: Boolean): Unit
+
+  /**
+    * Alters existed database into external Catalog
+    */
+  def alterDatabase(db: ExternalCatalogDatabase): Unit
+
+  /**
+    * Gets database from external Catalog
+    *
+    * @param dbName database name
+    * @return database
+    */
+  def getDatabase(dbName: String): ExternalCatalogDatabase
+
+  /**
+    * Gets the database name lists from current external Catalog
+    *
+    * @return
+    */
+  def listDatabases(): Seq[String]
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalog.scala
@@ -18,15 +18,76 @@
 
 package org.apache.flink.table.catalog
 
+import org.apache.flink.table.catalog.ExternalCatalogTypes.PartitionSpec
+
 /**
   * This class is responsible for interact with external catalog.
   * Its main responsibilities including:
   * <ul>
-  * <li> create/drop/alter database or tables for DDL operations
+  * <li> create/drop/alter database, tables, partitions for DDL operations
   * <li> provide tables for calcite catalog, it looks up databases or tables in the external catalog
   * </ul>
   */
 trait ExternalCatalog {
+
+  /**
+    * Adds partitions into an external Catalog table
+    *
+    * @param dbName         database name
+    * @param tableName      table name
+    * @param part           partition description of partition which to create
+    * @param ignoreIfExists whether to ignore operation if table already exists
+    */
+  def createPartition(
+      dbName: String,
+      tableName: String,
+      part: ExternalCatalogTablePartition,
+      ignoreIfExists: Boolean): Unit
+
+  /**
+    * Deletes partition of an external Catalog table
+    *
+    * @param dbName            database name
+    * @param tableName         table name
+    * @param partSpec          partition specification
+    * @param ignoreIfNotExists whether to ignore operation if table not exist yet
+    */
+  def dropPartition(
+      dbName: String,
+      tableName: String,
+      partSpec: PartitionSpec,
+      ignoreIfNotExists: Boolean): Unit
+
+  /**
+    * Alters an existed external Catalog table partition
+    *
+    * @param dbName    database name
+    * @param tableName table name
+    * @param part      description of partition which to alter
+    */
+  def alterPartition(dbName: String, tableName: String, part: ExternalCatalogTablePartition): Unit
+
+  /**
+    * Gets the partition from external Catalog
+    *
+    * @param dbName    database name
+    * @param tableName table name
+    * @param partSpec  partition specification
+    * @return
+    */
+  def getPartition(
+      dbName: String,
+      tableName: String,
+      partSpec: PartitionSpec): ExternalCatalogTablePartition
+
+  /**
+    * Gets the partition specification list of a table from external catalog
+    *
+    * @param dbName    database name
+    * @param tableName table name
+    * @return
+    */
+  def listPartitionSpec(dbName: String, tableName: String): Seq[PartitionSpec]
 
   /**
     * Adds table into external Catalog

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogDatabase.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogDatabase.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+/**
+  * Database definition of the external catalog.
+  *
+  * @param dbName     database name
+  * @param properties database properties
+  */
+case class ExternalCatalogDatabase(
+    dbName: String,
+    properties: Map[String, String] = Map.empty)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogSchema.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogSchema.scala
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+import java.util
+
+import org.apache.calcite.linq4j.tree.Expression
+import org.apache.calcite.schema._
+import org.apache.flink.table.api.{DatabaseNotExistException, TableNotExistException}
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.collection.JavaConverters._
+
+/**
+  * This class is responsible for connect external catalog to calcite catalog.
+  * In this way, it is possible to look-up and access tables in SQL queries
+  * without registering tables in advance.
+  * The databases in the external catalog registers as calcite sub-Schemas of current schema.
+  * The tables in a given database registers as calcite tables
+  * of the [[ExternalCatalogDatabaseSchema]].
+  *
+  * @param catalogIdentifier external catalog name
+  * @param catalog           external catalog
+  */
+class ExternalCatalogSchema(
+    catalogIdentifier: String,
+    catalog: ExternalCatalog) extends Schema {
+
+  private val LOG: Logger = LoggerFactory.getLogger(this.getClass)
+
+  /**
+    * Looks up database by the given sub-schema name in the external catalog,
+    * returns it Wrapped in a [[ExternalCatalogDatabaseSchema]] with the given database name.
+    *
+    * @param name Sub-schema name
+    * @return Sub-schema with a given name, or null
+    */
+  override def getSubSchema(name: String): Schema = {
+    try {
+      val db = catalog.getDatabase(name)
+      if (db != null) {
+        new ExternalCatalogDatabaseSchema(db.dbName, catalog)
+      } else {
+        null
+      }
+    } catch {
+      case e: DatabaseNotExistException =>
+        LOG.warn(s"database $name does not exist in externalCatalog $catalogIdentifier")
+        null
+    }
+  }
+
+  /**
+    * Lists the databases of the external catalog,
+    * returns the lists as the names of this schema's sub-schemas.
+    *
+    * @return names of this schema's child schemas
+    */
+  override def getSubSchemaNames: util.Set[String] = catalog.listDatabases().toSet.asJava
+
+  override def getTable(name: String): Table = null
+
+  override def isMutable: Boolean = true
+
+  override def getFunctions(name: String): util.Collection[Function] =
+    util.Collections.emptyList[Function]
+
+  override def getExpression(parentSchema: SchemaPlus, name: String): Expression =
+    Schemas.subSchemaExpression(parentSchema, name, getClass)
+
+  override def getFunctionNames: util.Set[String] = util.Collections.emptySet[String]
+
+  override def getTableNames: util.Set[String] = util.Collections.emptySet[String]
+
+  override def contentsHaveChangedSince(lastCheck: Long, now: Long): Boolean = false
+
+  /**
+    * Registers sub-Schemas to current schema plus
+    *
+    * @param plusOfThis
+    */
+  def registerSubSchemas(plusOfThis: SchemaPlus) {
+    catalog.listDatabases().foreach(
+      dbName => plusOfThis.add(dbName, getSubSchema(dbName))
+    )
+  }
+
+  private class ExternalCatalogDatabaseSchema(
+      schemaName: String,
+      flinkExternalCatalog: ExternalCatalog) extends Schema {
+
+    override def getTable(name: String): Table = {
+      try {
+        val externalCatalogTable = flinkExternalCatalog.getTable(schemaName, name)
+        if (externalCatalogTable != null) {
+          CatalogTableHelper.fromExternalCatalogTable(externalCatalogTable)
+        } else {
+          null
+        }
+      } catch {
+        case TableNotExistException(db, table, cause) => {
+          LOG.warn(s"table $db.$table does not exist in externalCatalog $catalogIdentifier")
+          null
+        }
+      }
+    }
+
+    override def getTableNames: util.Set[String] =
+      flinkExternalCatalog.listTables(schemaName).toSet.asJava
+
+    override def getSubSchema(name: String): Schema = null
+
+    override def getSubSchemaNames: util.Set[String] = util.Collections.emptySet[String]
+
+    override def isMutable: Boolean = true
+
+    override def getFunctions(name: String): util.Collection[Function] =
+      util.Collections.emptyList[Function]
+
+    override def getExpression(parentSchema: SchemaPlus, name: String): Expression =
+      Schemas.subSchemaExpression(parentSchema, name, getClass)
+
+    override def getFunctionNames: util.Set[String] = util.Collections.emptySet[String]
+
+    override def contentsHaveChangedSince(lastCheck: Long, now: Long): Boolean = false
+
+  }
+
+}
+
+object ExternalCatalogSchema {
+
+  /**
+    * Creates a FlinkExternalCatalogSchema.
+    *
+    * @param parentSchema              Parent schema
+    * @param externalCatalogIdentifier External catalog identifier
+    * @param externalCatalog           External catalog object
+    * @return Created schema
+    */
+  def create(
+      parentSchema: SchemaPlus,
+      externalCatalogIdentifier: String,
+      externalCatalog: ExternalCatalog): ExternalCatalogSchema = {
+    val newSchema = new ExternalCatalogSchema(externalCatalogIdentifier, externalCatalog)
+    val schemaPlusOfNewSchema = parentSchema.add(externalCatalogIdentifier, newSchema)
+    newSchema.registerSubSchemas(schemaPlusOfNewSchema)
+    newSchema
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.table.plan.stats.TableStats
+
+/**
+  * Table definition of the external catalog.
+  *
+  * @param identifier           identifier of external catalog table, including dbName and tableName
+  * @param tableType            type of external catalog table, e.g csv, hbase, kafka
+  * @param schema               schema of table data, including column names and column types
+  * @param properties           properties of external catalog table
+  * @param stats                statistics of external catalog table
+  * @param comment              comment of external catalog table
+  * @param createTime           create time of external catalog table
+  * @param lastAccessTime       last access time of of external catalog table
+  */
+case class ExternalCatalogTable(
+    identifier: TableIdentifier,
+    tableType: String,
+    schema: DataSchema,
+    properties: Map[String, String] = Map.empty,
+    stats: Option[TableStats] = None,
+    comment: Option[String] = None,
+    createTime: Long = System.currentTimeMillis,
+    lastAccessTime: Long = -1)
+
+/**
+  * Identifier of external catalog table
+  *
+  * @param database database name
+  * @param table    table name
+  */
+case class TableIdentifier(
+    database: String,
+    table: String) {
+
+  override def toString: String = s"$database.$table"
+
+}
+
+/**
+  * Schema of External catalog table's columns
+  *
+  * @param columnTypes types of each column
+  * @param columnNames names of each column
+  */
+case class DataSchema(
+    columnTypes: Array[TypeInformation[_]],
+    columnNames: Array[String])

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
@@ -40,6 +40,7 @@ case class ExternalCatalogTable(
     properties: Map[String, String] = Map.empty,
     stats: Option[TableStats] = None,
     comment: Option[String] = None,
+    partitionColumnNames: Seq[String] = Seq.empty,
     createTime: Long = System.currentTimeMillis,
     lastAccessTime: Long = -1)
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTablePartition.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTablePartition.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+import org.apache.flink.table.plan.stats.TablePartitionStats
+
+object ExternalCatalogTypes {
+
+  /**
+    * external table partition specification.
+    * Key is partition column name, value is partition column value.
+    */
+  type PartitionSpec = Map[String, String]
+}
+
+/**
+  * Partition definition of an external Catalog table
+  *
+  * @param partitionSpec partition specification
+  * @param properties    partition properties
+  * @param stats         partition statistics
+  */
+case class ExternalCatalogTablePartition(
+    partitionSpec: ExternalCatalogTypes.PartitionSpec,
+    properties: Map[String, String] = Map.empty,
+    stats: Option[TablePartitionStats] = None)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/InMemoryExternalCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/InMemoryExternalCatalog.scala
@@ -18,9 +18,10 @@
 
 package org.apache.flink.table.catalog
 
-import org.apache.flink.table.api.{DatabaseAlreadyExistException, DatabaseNotExistException, TableAlreadyExistException, TableNotExistException}
+import org.apache.flink.table.api._
+import org.apache.flink.table.catalog.ExternalCatalogTypes.PartitionSpec
 
-import scala.collection.mutable.HashMap
+import _root_.scala.collection.mutable
 
 /**
   * This class is an in-memory implementation of [[ExternalCatalog]].
@@ -29,7 +30,7 @@ import scala.collection.mutable.HashMap
   */
 class InMemoryExternalCatalog extends ExternalCatalog {
 
-  private val databases = new HashMap[String, Database]
+  private val databases = new mutable.HashMap[String, DatabaseDesc]
 
   override def createTable(
       table: ExternalCatalogTable,
@@ -37,10 +38,12 @@ class InMemoryExternalCatalog extends ExternalCatalog {
     val dbName = table.identifier.database
     val tables = getTables(dbName)
     val tableName = table.identifier.table
-    if (tables.contains(tableName) && !ignoreIfExists) {
-      throw new TableAlreadyExistException(dbName, tableName)
+    if (tables.contains(tableName)) {
+      if (!ignoreIfExists) {
+        throw new TableAlreadyExistException(dbName, tableName)
+      }
     } else {
-      tables.put(tableName, table)
+      tables.put(tableName, new TableDesc(table))
     }
   }
 
@@ -55,14 +58,8 @@ class InMemoryExternalCatalog extends ExternalCatalog {
   }
 
   override def alterTable(table: ExternalCatalogTable): Unit = synchronized {
-    val dbName = table.identifier.database
-    val tables = getTables(dbName)
-    val tableName = table.identifier.table
-    if (tables.contains(tableName)) {
-      tables.put(tableName, table)
-    } else {
-      throw new TableNotExistException(dbName, tableName)
-    }
+    val tableDesc = getTableDesc(table.identifier.database, table.identifier.table)
+    tableDesc.table = table
   }
 
   override def listTables(dbName: String): Seq[String] = synchronized {
@@ -71,21 +68,20 @@ class InMemoryExternalCatalog extends ExternalCatalog {
   }
 
   override def getTable(dbName: String, tableName: String): ExternalCatalogTable = synchronized {
-    val tables = getTables(dbName)
-    tables.get(tableName) match {
-      case Some(table) => table
-      case None => throw new TableNotExistException(dbName, tableName)
-    }
+    val tableDesc = getTableDesc(dbName, tableName)
+    tableDesc.table
   }
 
   override def createDatabase(
       db: ExternalCatalogDatabase,
       ignoreIfExists: Boolean): Unit = synchronized {
     val dbName = db.dbName
-    if (databases.contains(dbName) && !ignoreIfExists) {
-      throw new DatabaseAlreadyExistException(dbName)
+    if (databases.contains(dbName)) {
+      if (!ignoreIfExists) {
+        throw new DatabaseAlreadyExistException(dbName)
+      }
     } else {
-      databases.put(dbName, new Database(db))
+      databases.put(dbName, new DatabaseDesc(db))
     }
   }
 
@@ -116,14 +112,109 @@ class InMemoryExternalCatalog extends ExternalCatalog {
     }
   }
 
-  private def getTables(db: String): HashMap[String, ExternalCatalogTable] =
+  override def createPartition(
+      dbName: String,
+      tableName: String,
+      part: ExternalCatalogTablePartition,
+      ignoreIfExists: Boolean): Unit = synchronized {
+    val newPartSpec = part.partitionSpec
+    val partitionedTable = getPartitionedTable(dbName, tableName)
+    checkPartitionSpec(newPartSpec, partitionedTable.table)
+    if (partitionedTable.partitions.contains(newPartSpec)) {
+      if (!ignoreIfExists) {
+        throw new PartitionAlreadyExistException(dbName, tableName, newPartSpec)
+      }
+    } else {
+      partitionedTable.partitions.put(newPartSpec, part)
+    }
+  }
+
+  override def getPartition(
+      dbName: String,
+      tableName: String,
+      partSpec: PartitionSpec): ExternalCatalogTablePartition = synchronized {
+    val partitionedTable = getPartitionedTable(dbName, tableName)
+    checkPartitionSpec(partSpec, partitionedTable.table)
+    partitionedTable.partitions.get(partSpec) match {
+      case Some(part) => part
+      case None =>
+        throw new PartitionNotExistException(dbName, tableName, partSpec)
+    }
+  }
+
+  override def dropPartition(
+      dbName: String,
+      tableName: String,
+      partSpec: PartitionSpec,
+      ignoreIfNotExists: Boolean): Unit = synchronized {
+    val partitionedTable = getPartitionedTable(dbName, tableName)
+    checkPartitionSpec(partSpec, partitionedTable.table)
+    if (partitionedTable.partitions.remove(partSpec).isEmpty && !ignoreIfNotExists) {
+      throw new PartitionNotExistException(dbName, tableName, partSpec)
+    }
+  }
+
+  override def listPartitionSpec(
+      dbName: String,
+      tableName: String): Seq[PartitionSpec] = synchronized {
+    getPartitionedTable(dbName, tableName).partitions.keys.toSeq
+  }
+
+  override def alterPartition(
+      dbName: String,
+      tableName: String,
+      part: ExternalCatalogTablePartition): Unit = synchronized {
+    val updatedPartSpec = part.partitionSpec
+    val partitionedTable = getPartitionedTable(dbName, tableName)
+    checkPartitionSpec(updatedPartSpec, partitionedTable.table)
+    if (partitionedTable.partitions.contains(updatedPartSpec)) {
+      partitionedTable.partitions.put(updatedPartSpec, part)
+    } else {
+      throw new PartitionNotExistException(dbName, tableName, updatedPartSpec)
+    }
+  }
+
+  private def getTables(db: String): mutable.HashMap[String, TableDesc] =
     databases.get(db) match {
       case Some(database) => database.tables
       case None => throw new DatabaseNotExistException(db)
     }
 
-  private class Database(var db: ExternalCatalogDatabase) {
-    val tables = new HashMap[String, ExternalCatalogTable]
+  private def getTableDesc(
+      dbName: String,
+      tableName: String): TableDesc = {
+    val tables = getTables(dbName)
+    tables.get(tableName) match {
+      case Some(tableDesc) => tableDesc
+      case None =>
+        throw new TableNotExistException(dbName, tableName)
+    }
+  }
+
+  private def getPartitionedTable(
+      dbName: String,
+      tableName: String): TableDesc = {
+    val tableDesc = getTableDesc(dbName, tableName)
+    val table = tableDesc.table
+    if (table.partitionColumnNames.isEmpty) {
+      throw new UnsupportedOperationException(
+        s"cannot do any operation about partition on the non-partitioned table ${table.identifier}")
+    } else {
+      tableDesc
+    }
+  }
+
+  private def checkPartitionSpec(partSpec: PartitionSpec, table: ExternalCatalogTable): Unit =
+    if (partSpec.keySet != table.partitionColumnNames.toSet) {
+      throw new IllegalArgumentException("Input partition specification is invalid!")
+    }
+
+  private class DatabaseDesc(var db: ExternalCatalogDatabase) {
+    val tables = new mutable.HashMap[String, TableDesc]
+  }
+
+  private class TableDesc(var table: ExternalCatalogTable) {
+    val partitions = new mutable.HashMap[PartitionSpec, ExternalCatalogTablePartition]
   }
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/InMemoryExternalCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/InMemoryExternalCatalog.scala
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+import org.apache.flink.table.api.{DatabaseAlreadyExistException, DatabaseNotExistException, TableAlreadyExistException, TableNotExistException}
+
+import scala.collection.mutable.HashMap
+
+/**
+  * This class is an in-memory implementation of [[ExternalCatalog]].
+  *
+  * It could be used for testing or developing instead of used in production environment.
+  */
+class InMemoryExternalCatalog extends ExternalCatalog {
+
+  private val databases = new HashMap[String, Database]
+
+  override def createTable(
+      table: ExternalCatalogTable,
+      ignoreIfExists: Boolean): Unit = synchronized {
+    val dbName = table.identifier.database
+    val tables = getTables(dbName)
+    val tableName = table.identifier.table
+    if (tables.contains(tableName) && !ignoreIfExists) {
+      throw new TableAlreadyExistException(dbName, tableName)
+    } else {
+      tables.put(tableName, table)
+    }
+  }
+
+  override def dropTable(
+      dbName: String,
+      tableName: String,
+      ignoreIfNotExists: Boolean): Unit = synchronized {
+    val tables = getTables(dbName)
+    if (tables.remove(tableName).isEmpty && !ignoreIfNotExists) {
+      throw new TableNotExistException(dbName, tableName)
+    }
+  }
+
+  override def alterTable(table: ExternalCatalogTable): Unit = synchronized {
+    val dbName = table.identifier.database
+    val tables = getTables(dbName)
+    val tableName = table.identifier.table
+    if (tables.contains(tableName)) {
+      tables.put(tableName, table)
+    } else {
+      throw new TableNotExistException(dbName, tableName)
+    }
+  }
+
+  override def listTables(dbName: String): Seq[String] = synchronized {
+    val tables = getTables(dbName)
+    tables.keys.toSeq
+  }
+
+  override def getTable(dbName: String, tableName: String): ExternalCatalogTable = synchronized {
+    val tables = getTables(dbName)
+    tables.get(tableName) match {
+      case Some(table) => table
+      case None => throw new TableNotExistException(dbName, tableName)
+    }
+  }
+
+  override def createDatabase(
+      db: ExternalCatalogDatabase,
+      ignoreIfExists: Boolean): Unit = synchronized {
+    val dbName = db.dbName
+    if (databases.contains(dbName) && !ignoreIfExists) {
+      throw new DatabaseAlreadyExistException(dbName)
+    } else {
+      databases.put(dbName, new Database(db))
+    }
+  }
+
+  override def alterDatabase(db: ExternalCatalogDatabase): Unit = synchronized {
+    val dbName = db.dbName
+    databases.get(dbName) match {
+      case Some(database) => database.db = db
+      case None => throw new DatabaseNotExistException(dbName)
+    }
+  }
+
+  override def dropDatabase(
+      dbName: String,
+      ignoreIfNotExists: Boolean): Unit = synchronized {
+    if (databases.remove(dbName).isEmpty && !ignoreIfNotExists) {
+      throw new DatabaseNotExistException(dbName)
+    }
+  }
+
+  override def listDatabases(): Seq[String] = synchronized {
+    databases.keys.toSeq
+  }
+
+  override def getDatabase(dbName: String): ExternalCatalogDatabase = synchronized {
+    databases.get(dbName) match {
+      case Some(database) => database.db
+      case None => null
+    }
+  }
+
+  private def getTables(db: String): HashMap[String, ExternalCatalogTable] =
+    databases.get(db) match {
+      case Some(database) => database.tables
+      case None => throw new DatabaseNotExistException(db)
+    }
+
+  private class Database(var db: ExternalCatalogDatabase) {
+    val tables = new HashMap[String, ExternalCatalogTable]
+  }
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/TableSourceConverter.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/TableSourceConverter.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+import org.apache.flink.table.sources.TableSource
+
+/** Defines a converter used to convert [[org.apache.flink.table.sources.TableSource]] to
+  * or from [[ExternalCatalogTable]].
+  *
+  * @tparam T The tableSource type which to do convert operation on.
+  */
+trait TableSourceConverter[T <: TableSource[_]] {
+
+  /**
+    * Converts the input external catalog table instance to a tableSource instance.
+    *
+    * @param externalCatalogTable input external catalog table instance to convert
+    * @return converted tableSource instance from input external catalog table.
+    */
+  def fromExternalCatalogTable(externalCatalogTable: ExternalCatalogTable): T
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/stats/TablePartitionStats.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/stats/TablePartitionStats.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.stats
+
+import java.util.{HashMap, Map}
+
+/**
+  * Table statistics
+  *
+  * @param rowCount cardinality of table
+  * @param colStats statistics of table columns
+  */
+case class TablePartitionStats(rowCount: Long, colStats: Map[String, ColumnStats] = new HashMap())

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/CsvTableSource.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/CsvTableSource.scala
@@ -27,6 +27,7 @@ import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.core.fs.Path
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.table.annotation.ExternalCatalogCompatible
 import org.apache.flink.table.api.TableException
 
 import scala.collection.mutable
@@ -45,6 +46,8 @@ import scala.collection.mutable
   * @param ignoreComments An optional prefix to indicate comments, null by default.
   * @param lenient Flag to skip records with parse error instead to fail, false by default.
   */
+
+@ExternalCatalogCompatible(tableType = "csv", converter = classOf[CsvTableSourceConverter])
 class CsvTableSource(
     private val path: String,
     private val fieldNames: Array[String],

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/CsvTableSourceConverter.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/CsvTableSourceConverter.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sources
+
+import org.apache.flink.table.catalog.{ExternalCatalogTable, TableSourceConverter}
+
+/**
+  * The class defines a converter used to convert [[CsvTableSource]] to
+  * or from [[ExternalCatalogTable]].
+  */
+class CsvTableSourceConverter extends TableSourceConverter[CsvTableSource] {
+
+  override def fromExternalCatalogTable(
+      externalCatalogTable: ExternalCatalogTable): CsvTableSource = {
+
+    val csvTableSourceBuilder = new CsvTableSource.Builder
+    val params = externalCatalogTable.properties
+    params.get("path").foreach(csvTableSourceBuilder.path)
+    params.get("fieldDelim").foreach(csvTableSourceBuilder.fieldDelimiter)
+    params.get("rowDelim").foreach(csvTableSourceBuilder.lineDelimiter)
+    params.get("quoteCharacter").foreach(quoteStr =>
+      if (quoteStr.length != 1) {
+        throw new IllegalArgumentException("the value of param quoteCharacter is invalid")
+      } else {
+        csvTableSourceBuilder.quoteCharacter(quoteStr.charAt(0))
+      }
+    )
+    params.get("ignoreFirstLine").foreach(ignoreFirstLineStr =>
+        if(ignoreFirstLineStr.toBoolean) {
+          csvTableSourceBuilder.ignoreFirstLine()
+        }
+    )
+    params.get("ignoreComments").foreach(csvTableSourceBuilder.commentPrefix)
+    params.get("lenient").foreach(lenientStr =>
+        if(lenientStr.toBoolean) {
+          csvTableSourceBuilder.ignoreParseErrors
+        }
+    )
+    externalCatalogTable.schema.columnNames
+        .zip(externalCatalogTable.schema.columnTypes)
+        .foreach(field => csvTableSourceBuilder.field(field._1, field._2))
+
+    csvTableSourceBuilder.build()
+  }
+
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/catalog/ExternalCatalogSchemaTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/catalog/ExternalCatalogSchemaTest.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+import java.util.Collections
+
+import com.google.common.collect.Lists
+import org.apache.calcite.jdbc.CalciteSchema
+import org.apache.calcite.prepare.CalciteCatalogReader
+import org.apache.calcite.schema.SchemaPlus
+import org.apache.calcite.sql.validate.SqlMonikerType
+import org.apache.commons.collections.CollectionUtils
+import org.apache.flink.table.calcite.{FlinkTypeFactory, FlinkTypeSystem}
+import org.apache.flink.table.plan.schema.TableSourceTable
+import org.apache.flink.table.sources.CsvTableSource
+import org.apache.flink.table.utils.CommonTestData
+import org.junit.{Before, Test}
+import org.junit.Assert._
+
+class ExternalCatalogSchemaTest {
+
+  private val schemaName: String = "test"
+  private var externalCatalogSchema: ExternalCatalogSchema = _
+  private var calciteCatalogReader: CalciteCatalogReader = _
+  private val db = "db1"
+  private val tb = "tb1"
+
+  @Before
+  def setUp(): Unit = {
+    val rootSchemaPlus: SchemaPlus = CalciteSchema.createRootSchema(true, false).plus()
+    val catalog = CommonTestData.getMockedFlinkExternalCatalog
+    externalCatalogSchema = ExternalCatalogSchema.create(rootSchemaPlus, schemaName, catalog)
+    val typeFactory = new FlinkTypeFactory(new FlinkTypeSystem())
+    calciteCatalogReader = new CalciteCatalogReader(
+      CalciteSchema.from(rootSchemaPlus),
+      false,
+      Collections.emptyList(),
+      typeFactory)
+  }
+
+  @Test
+  def testGetSubSchema(): Unit = {
+    val allSchemaObjectNames = calciteCatalogReader
+        .getAllSchemaObjectNames(Lists.newArrayList(schemaName))
+    assertTrue(allSchemaObjectNames.size() == 2)
+    assertEquals(SqlMonikerType.SCHEMA, allSchemaObjectNames.get(0).getType)
+    assertTrue(
+      CollectionUtils.isEqualCollection(
+        allSchemaObjectNames.get(0).getFullyQualifiedNames,
+        Lists.newArrayList(schemaName, db)
+      ))
+  }
+
+  @Test
+  def testGetTable(): Unit = {
+    val relOptTable = calciteCatalogReader.getTable(Lists.newArrayList(schemaName, db, tb))
+    assertNotNull(relOptTable)
+    val tableSourceTable = relOptTable.unwrap(classOf[TableSourceTable[_]])
+    tableSourceTable match {
+      case tst: TableSourceTable[_] =>
+        assertTrue(tst.tableSource.isInstanceOf[CsvTableSource])
+      case _ =>
+        fail("unexpected table type!")
+    }
+  }
+
+  @Test
+  def testGetNotExistTable(): Unit = {
+    val relOptTable = calciteCatalogReader.getTable(
+      Lists.newArrayList(schemaName, db, "nonexist-tb"))
+    assertNull(relOptTable)
+  }
+
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/catalog/InMemoryExternalCatalogTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/catalog/InMemoryExternalCatalogTest.scala
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo
+import org.apache.flink.table.api.{DatabaseAlreadyExistException, DatabaseNotExistException, TableAlreadyExistException, TableNotExistException}
+import org.junit.{Before, Test}
+import org.junit.Assert._
+
+class InMemoryExternalCatalogTest {
+
+  private val databaseName = "db1"
+
+  private var catalog: InMemoryExternalCatalog = _
+
+  @Before
+  def setUp(): Unit = {
+    catalog = new InMemoryExternalCatalog()
+    catalog.createDatabase(ExternalCatalogDatabase(databaseName), ignoreIfExists = false)
+  }
+
+  @Test
+  def testCreateTable(): Unit = {
+    assertTrue(catalog.listTables(databaseName).isEmpty)
+    catalog.createTable(createTableInstance(databaseName, "t1"), ignoreIfExists = false)
+    assertTrue(catalog.listTables(databaseName).toSet == Set("t1"))
+  }
+
+  @Test(expected = classOf[TableAlreadyExistException])
+  def testCreateExistedTable(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(createTableInstance(databaseName, tableName), false)
+    catalog.createTable(createTableInstance(databaseName, tableName), false)
+  }
+
+  @Test
+  def testGetTable(): Unit = {
+    val originTable = createTableInstance(databaseName, "t1")
+    catalog.createTable(originTable, false)
+    assertEquals(catalog.getTable(databaseName, "t1"), originTable)
+  }
+
+  @Test(expected = classOf[DatabaseNotExistException])
+  def testGetTableUnderNotExistDatabaseName(): Unit = {
+    catalog.getTable("notexistedDb", "t1")
+  }
+
+  @Test(expected = classOf[TableNotExistException])
+  def testGetNotExistTable(): Unit = {
+    catalog.getTable(databaseName, "t1")
+  }
+
+  @Test
+  def testAlterTable(): Unit = {
+    val tableName = "t1"
+    val table = createTableInstance(databaseName, tableName)
+    catalog.createTable(table, false)
+    assertEquals(catalog.getTable(databaseName, tableName), table)
+    val newTable = createTableInstance(databaseName, tableName)
+    catalog.alterTable(newTable)
+    val currentTable = catalog.getTable(databaseName, tableName)
+    // validate the table is really replaced after alter table
+    assertNotEquals(table, currentTable)
+    assertEquals(newTable, currentTable)
+  }
+
+  @Test(expected = classOf[TableNotExistException])
+  def testAlterNotExistTable(): Unit = {
+    catalog.alterTable(createTableInstance(databaseName, "t1"))
+  }
+
+  @Test
+  def testDropTable(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(createTableInstance(databaseName, tableName), false)
+    assertTrue(catalog.listTables(databaseName).contains(tableName))
+    catalog.dropTable(databaseName, tableName, false)
+    assertFalse(catalog.listTables(databaseName).contains(tableName))
+  }
+
+  @Test(expected = classOf[TableNotExistException])
+  def testDropNotExistTable(): Unit = {
+    catalog.dropTable(databaseName, "t1", false)
+  }
+
+  @Test
+  def testListDatabases(): Unit = {
+    assertTrue(catalog.listDatabases().toSet == Set(databaseName))
+  }
+
+  @Test
+  def testGetDatabase(): Unit = {
+    assertNotNull(catalog.getDatabase(databaseName))
+  }
+
+  @Test
+  def testGetNotExistDatabase(): Unit = {
+    assertNull(catalog.getDatabase("notexistedDb"))
+  }
+
+  @Test
+  def testCreateDatabase(): Unit = {
+    val originDatabasesNum = catalog.listDatabases().size
+    catalog.createDatabase(ExternalCatalogDatabase("db2"), false)
+    assertEquals(catalog.listDatabases().size, originDatabasesNum + 1)
+  }
+
+  @Test(expected = classOf[DatabaseAlreadyExistException])
+  def testCreateExistedDatabase(): Unit = {
+    catalog.createDatabase(ExternalCatalogDatabase(databaseName), false)
+  }
+
+  private def createTableInstance(dbName: String, tableName: String): ExternalCatalogTable = {
+    val tableSourceClazzName = "org.apache.flink.table.sources.DemoTableSource"
+    val schema = new DataSchema(
+      Array(
+        BasicTypeInfo.STRING_TYPE_INFO,
+        BasicTypeInfo.INT_TYPE_INFO
+      ),
+      Array("first", "second"))
+    ExternalCatalogTable(
+      TableIdentifier(dbName, tableName),
+      tableSourceClazzName,
+      schema)
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/catalog/InMemoryExternalCatalogTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/catalog/InMemoryExternalCatalogTest.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.catalog
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo
-import org.apache.flink.table.api.{DatabaseAlreadyExistException, DatabaseNotExistException, TableAlreadyExistException, TableNotExistException}
+import org.apache.flink.table.api._
 import org.junit.{Before, Test}
 import org.junit.Assert._
 
@@ -36,24 +36,172 @@ class InMemoryExternalCatalogTest {
   }
 
   @Test
+  def testCreatePartition(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    assertTrue(catalog.listPartitionSpec(databaseName, tableName).isEmpty)
+    val newPartitionSpec = Map("hour"->"12", "ds"->"2016-02-01")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    catalog.createPartition(databaseName, tableName, newPartition, false)
+    assertTrue(catalog.listPartitionSpec(databaseName, tableName).toSet == Set(newPartitionSpec))
+  }
+
+  @Test(expected = classOf[UnsupportedOperationException])
+  def testCreatePartitionOnUnPartitionedTable(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createNonPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    val newPartitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    catalog.createPartition(databaseName, tableName, newPartition, false)
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testCreateInvalidPartitionSpec(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    val newPartitionSpec = Map("ds"->"2016-02-01", "h"->"12")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    catalog.createPartition(databaseName, tableName, newPartition, false)
+  }
+
+  @Test(expected = classOf[PartitionAlreadyExistException])
+  def testCreateExistedPartition(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    val newPartitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    catalog.createPartition(databaseName, tableName, newPartition, false)
+    val newPartitionSpec1 = Map("hour"->"12", "ds"->"2016-02-01")
+    val newPartition1 = ExternalCatalogTablePartition(newPartitionSpec1)
+    catalog.createPartition(databaseName, tableName, newPartition1, false)
+  }
+
+  @Test(expected = classOf[TableNotExistException])
+  def testCreatePartitionOnNotExistTable(): Unit = {
+    val newPartitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    catalog.createPartition(databaseName, "notexistedTb", newPartition, false)
+  }
+
+  @Test(expected = classOf[DatabaseNotExistException])
+  def testCreatePartitionOnNotExistDatabase(): Unit = {
+    val tableName = "t1"
+    val newPartitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    catalog.createPartition("notexistedDb", tableName, newPartition, false)
+  }
+
+  @Test
+  def testGetPartition(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    val newPartitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    catalog.createPartition(databaseName, tableName, newPartition, false)
+    assertEquals(catalog.getPartition(databaseName, tableName, newPartitionSpec), newPartition)
+  }
+
+  @Test(expected = classOf[PartitionNotExistException])
+  def testGetNotExistPartition(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    val newPartitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    assertEquals(catalog.getPartition(databaseName, tableName, newPartitionSpec), newPartition)
+  }
+
+  @Test
+  def testDropPartition(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    val newPartitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    catalog.createPartition(databaseName, tableName, newPartition, false)
+    assertTrue(catalog.listPartitionSpec(databaseName, tableName).contains(newPartitionSpec))
+    catalog.dropPartition(databaseName, tableName, newPartitionSpec, false)
+    assertFalse(catalog.listPartitionSpec(databaseName, tableName).contains(newPartitionSpec))
+  }
+
+  @Test(expected = classOf[PartitionNotExistException])
+  def testDropNotExistPartition(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    val partitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    catalog.dropPartition(databaseName, tableName, partitionSpec, false)
+  }
+
+  @Test
+  def testListPartitionSpec(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    assertTrue(catalog.listPartitionSpec(databaseName, tableName).isEmpty)
+    val newPartitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    catalog.createPartition(databaseName, tableName, newPartition, false)
+    assertEquals(catalog.listPartitionSpec(databaseName, tableName), Seq(newPartitionSpec))
+  }
+
+  @Test
+  def testAlterPartition(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    val newPartitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    val newPartition = ExternalCatalogTablePartition(
+      newPartitionSpec,
+      properties = Map("location" -> "/tmp/ds=2016-02-01/hour=12"))
+    catalog.createPartition(databaseName, tableName, newPartition, false)
+    val updatedPartition = ExternalCatalogTablePartition(
+      newPartitionSpec,
+      properties = Map("location" -> "/tmp1/ds=2016-02-01/hour=12"))
+    catalog.alterPartition(databaseName, tableName, updatedPartition)
+    val currentPartition = catalog.getPartition(databaseName, tableName, newPartitionSpec)
+    assertEquals(currentPartition, updatedPartition)
+    assertNotEquals(currentPartition, newPartition)
+  }
+
+  @Test
   def testCreateTable(): Unit = {
     assertTrue(catalog.listTables(databaseName).isEmpty)
-    catalog.createTable(createTableInstance(databaseName, "t1"), ignoreIfExists = false)
-    assertTrue(catalog.listTables(databaseName).toSet == Set("t1"))
+    val tableName = "t1"
+    catalog.createTable(
+      createNonPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    assertTrue(catalog.listTables(databaseName).toSet == Set(tableName))
   }
 
   @Test(expected = classOf[TableAlreadyExistException])
   def testCreateExistedTable(): Unit = {
     val tableName = "t1"
-    catalog.createTable(createTableInstance(databaseName, tableName), false)
-    catalog.createTable(createTableInstance(databaseName, tableName), false)
+    catalog.createTable(createNonPartitionedTableInstance(databaseName, tableName), false)
+    catalog.createTable(createNonPartitionedTableInstance(databaseName, tableName), false)
   }
 
   @Test
   def testGetTable(): Unit = {
-    val originTable = createTableInstance(databaseName, "t1")
+    val tableName = "t1"
+    val originTable = createNonPartitionedTableInstance(databaseName, tableName)
     catalog.createTable(originTable, false)
-    assertEquals(catalog.getTable(databaseName, "t1"), originTable)
+    assertEquals(catalog.getTable(databaseName, tableName), originTable)
   }
 
   @Test(expected = classOf[DatabaseNotExistException])
@@ -69,10 +217,10 @@ class InMemoryExternalCatalogTest {
   @Test
   def testAlterTable(): Unit = {
     val tableName = "t1"
-    val table = createTableInstance(databaseName, tableName)
+    val table = createNonPartitionedTableInstance(databaseName, tableName)
     catalog.createTable(table, false)
     assertEquals(catalog.getTable(databaseName, tableName), table)
-    val newTable = createTableInstance(databaseName, tableName)
+    val newTable = createNonPartitionedTableInstance(databaseName, tableName)
     catalog.alterTable(newTable)
     val currentTable = catalog.getTable(databaseName, tableName)
     // validate the table is really replaced after alter table
@@ -82,13 +230,13 @@ class InMemoryExternalCatalogTest {
 
   @Test(expected = classOf[TableNotExistException])
   def testAlterNotExistTable(): Unit = {
-    catalog.alterTable(createTableInstance(databaseName, "t1"))
+    catalog.alterTable(createNonPartitionedTableInstance(databaseName, "t1"))
   }
 
   @Test
   def testDropTable(): Unit = {
     val tableName = "t1"
-    catalog.createTable(createTableInstance(databaseName, tableName), false)
+    catalog.createTable(createNonPartitionedTableInstance(databaseName, tableName), false)
     assertTrue(catalog.listTables(databaseName).contains(tableName))
     catalog.dropTable(databaseName, tableName, false)
     assertFalse(catalog.listTables(databaseName).contains(tableName))
@@ -126,8 +274,9 @@ class InMemoryExternalCatalogTest {
     catalog.createDatabase(ExternalCatalogDatabase(databaseName), false)
   }
 
-  private def createTableInstance(dbName: String, tableName: String): ExternalCatalogTable = {
-    val tableSourceClazzName = "org.apache.flink.table.sources.DemoTableSource"
+  private def createNonPartitionedTableInstance(
+      dbName: String,
+      tableName: String): ExternalCatalogTable = {
     val schema = new DataSchema(
       Array(
         BasicTypeInfo.STRING_TYPE_INFO,
@@ -136,7 +285,25 @@ class InMemoryExternalCatalogTest {
       Array("first", "second"))
     ExternalCatalogTable(
       TableIdentifier(dbName, tableName),
-      tableSourceClazzName,
+      "csv",
       schema)
   }
+
+  private def createPartitionedTableInstance(
+      dbName: String,
+      tableName: String): ExternalCatalogTable = {
+    val schema = new DataSchema(
+      Array(
+        BasicTypeInfo.STRING_TYPE_INFO,
+        BasicTypeInfo.INT_TYPE_INFO
+      ),
+      Array("first", "second"))
+    ExternalCatalogTable(
+      TableIdentifier(dbName, tableName),
+      "hive",
+      schema,
+      partitionColumnNames = Array("ds","hour")
+    )
+  }
+
 }


### PR DESCRIPTION
在ExternalCatalog上增加partition的概念，包括：
1. 引入分区的Mode
2. 在ExternalCatalog上增加partition的增删改查接口
分为两个commit：
第一个commit对应https://github.com/beyond1920/flink/pull/2， 第二个commit是增加partition概念，review 这个pr只需要关注第二个commit即可。