### PR TITLE
[blink-9994904] 提供与ODPS对接的catalog实现

### DIFF
--- a/blink/blink-connectors/blink-connector-odps/pom.xml
+++ b/blink/blink-connectors/blink-connector-odps/pom.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>blink-connectors</artifactId>
+        <groupId>com.alibaba.blink</groupId>
+        <version>1.3-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.alibaba.blink</groupId>
+    <artifactId>blink-connector-odps</artifactId>
+    <version>1.3-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+            <!-- Projects depending on this project,
+            won't depend on flink-table. -->
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-java</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+            <!-- Projects depending on this project,
+            won't depend on flink-table. -->
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.aliyun.odps</groupId>
+            <artifactId>odps-sdk-core-internal</artifactId>
+            <version>0.26.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-core-asl</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.aliyun.odps</groupId>
+            <artifactId>odps-sdk-core</artifactId>
+            <version>0.21.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-core-asl</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!-- Disable inherited shade-flink because of a problem in the shade plugin -->
+                        <!-- When enabled you'll run into an infinite loop creating the dependency-reduced-pom.xml -->
+                        <!-- Seems similar to https://issues.apache.org/jira/browse/MSHADE-148 -->
+                        <id>shade-flink</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes combine.children="append">
+                                    <include>com.aliyun.odps:*</include>
+                                    <include>org.xerial.snappy:*</include>
+                                </includes>
+                            </artifactSet>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/ODPSTableSource.java
+++ b/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/ODPSTableSource.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.blink.odps;
+
+import com.alibaba.blink.odps.conf.ODPSConf;
+import com.alibaba.blink.odps.inputformat.ODPSInputFormat;
+import com.alibaba.blink.odps.inputformat.ODPSInputFormatBase;
+import com.alibaba.blink.odps.schema.ODPSColumn;
+import com.alibaba.blink.odps.schema.ODPSTableSchema;
+import com.alibaba.blink.odps.type.ODPSType;
+import com.alibaba.blink.odps.util.ODPSUtil;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.table.sources.BatchTableSource;
+import org.apache.flink.table.sources.ProjectableTableSource;
+import org.apache.flink.types.Row;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A [[BatchTableSource]] for ODPS table.
+ *
+ * Example :
+ * ODPSTableSource odpsTable = ODPSTableSource
+ * .builder()
+ * .setAccessId("accessId")
+ * .setAccessKey("accessKey")
+ * .setEndpoint("endpoint")
+ * .setProject("project")
+ * .setTable("table")
+ * .setPartitions(new String[]{"pt='1',ds='2'", "pt='1',ds='3'"})
+ * .build();
+ *
+ * Note: view is not supported yet
+ */
+public class ODPSTableSource implements BatchTableSource<Row>, ProjectableTableSource<Row> {
+
+	/** odps config */
+	private final ODPSConf odpsConf;
+
+	/** identify which table to fetch */
+	private final String table;
+
+	/** identify which partition to fetch */
+	private final String[] partitions;
+
+	/** odps table schema information */
+	private final ODPSTableSchema tableSchema;
+
+	/** return fields name */
+	private final String[] returnFieldsName;
+
+	/** return fields type */
+	private final TypeInformation<?>[] returnFieldsType;
+
+	/**
+	 * construct a new ODPSTableSource instance using odps config, table name,
+	 * selectedFieldNames(for project pushdown), partition(for partition pushdown)
+	 *
+	 * @param odpsConf   odps configuration
+	 * @param table      odps table name
+	 * @param partitions selected partitions(for partition pushdown). if this value is null or
+	 *                   blank, select all partitions of the table
+	 */
+	private ODPSTableSource(ODPSConf odpsConf, String table, String[] partitions) {
+		this.odpsConf = checkNotNull(odpsConf);
+		checkArgument(StringUtils.isNotBlank(table), "table is whitespace or null! ");
+		this.table = table;
+		this.tableSchema = ODPSUtil.getODPSTableSchema(odpsConf, table);
+		checkArgument(!tableSchema.isView(), "view is not supported yet! ");
+		if(tableSchema.isPartition() && ArrayUtils.isEmpty(partitions)) {
+			this.partitions = ODPSUtil.getAllPartitions(odpsConf, table);
+		} else {
+			this.partitions = partitions;
+		}
+		int columnsNum = tableSchema.getColumns().size();
+		this.returnFieldsName = new String[columnsNum];
+		this.returnFieldsType = new TypeInformation<?>[columnsNum];
+		for (int idx = 0; idx < columnsNum; idx++) {
+			ODPSColumn column = tableSchema.getColumns().get(idx);
+			returnFieldsName[idx] = column.getName();
+			returnFieldsType[idx] = ODPSType.valueOf(column.getType().name()).toFlinkType();
+		}
+	}
+
+	private ODPSTableSource(ODPSTableSource odpsTableSource, int[] projectFields) {
+		this.odpsConf = odpsTableSource.odpsConf;
+		this.table = odpsTableSource.table;
+		this.partitions = odpsTableSource.partitions;
+		this.tableSchema = odpsTableSource.tableSchema;
+		int projectFieldsNum = projectFields.length;
+		this.returnFieldsName = new String[projectFieldsNum];
+		this.returnFieldsType = new TypeInformation<?>[projectFieldsNum];
+		for (int idx = 0; idx < projectFieldsNum; idx++) {
+			int fieldLocation = projectFields[idx];
+			returnFieldsName[idx] = odpsTableSource.returnFieldsName[fieldLocation];
+			returnFieldsType[idx] = odpsTableSource.returnFieldsType[fieldLocation];
+		}
+	}
+
+	@Override
+	public DataSet<Row> getDataSet(ExecutionEnvironment execEnv) {
+		return execEnv.createInput(createODPSInputFormat(), getReturnType());
+	}
+
+	@Override
+	public TypeInformation<Row> getReturnType() {
+		return new RowTypeInfo(returnFieldsType, returnFieldsName);
+	}
+
+	@Override
+	public ProjectableTableSource<Row> projectFields(int[] fields) {
+		checkArgument(fields != null &&
+				fields.length != 0 &&
+				fields.length <= returnFieldsName.length,
+				"project fields cannot be null or empty, " +
+						"project fields number cannot be more than origin fields length!");
+		return new ODPSTableSource(this, fields);
+	}
+
+	public static ODPSTableSource.Builder builder() {
+		return new ODPSTableSource.Builder();
+	}
+
+	private ODPSInputFormatBase createODPSInputFormat() {
+		return new ODPSInputFormat(odpsConf, table, returnFieldsName, tableSchema, partitions);
+	}
+
+	public static class Builder {
+		/** ODPS configure */
+		private String accessId;
+		private String accessKey;
+		private String endpoint;
+		private String project;
+
+		/** identify which table to fetch */
+		private String table;
+
+		/** identify which partition to fetch */
+		private String[] partitions;
+
+		public Builder() {
+
+		}
+
+		public Builder setAccessId(String accessId) {
+			checkArgument(StringUtils.isNotBlank(accessId), "accessId is whitespace or null!");
+			this.accessId = accessId;
+			return this;
+		}
+
+		public Builder setAccessKey(String accessKey) {
+			checkArgument(StringUtils.isNotBlank(accessKey), "accessKey is whitespace or null!");
+			this.accessKey = accessKey;
+			return this;
+		}
+
+		public Builder setEndpoint(String endpoint) {
+			checkArgument(StringUtils.isNotBlank(endpoint), "endpoint is whitespace or null!");
+			this.endpoint = endpoint;
+			return this;
+		}
+
+		public Builder setProject(String project) {
+			checkArgument(StringUtils.isNotBlank(project), "project is whitespace or null! ");
+			this.project = project;
+			return this;
+		}
+
+		public Builder setTable(String table) {
+			checkArgument(StringUtils.isNotBlank(table), "table is whitespace or null! ");
+			this.table = table;
+			return this;
+		}
+
+		public Builder setPartitions(String[] partitions) {
+			this.partitions = partitions;
+			return this;
+		}
+
+		public ODPSTableSource build() {
+			ODPSConf odpsConf = new ODPSConf(accessId, accessKey, endpoint, project);
+			return new ODPSTableSource(odpsConf, table, partitions);
+		}
+	}
+}

--- a/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/ODPSTableSource.java
+++ b/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/ODPSTableSource.java
@@ -31,6 +31,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.table.annotation.ExternalCatalogCompatible;
 import org.apache.flink.table.sources.BatchTableSource;
 import org.apache.flink.table.sources.ProjectableTableSource;
 import org.apache.flink.types.Row;
@@ -54,6 +55,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *
  * Note: view is not supported yet
  */
+@ExternalCatalogCompatible(tableType = "odps", converter = ODPSTableSourceConverter.class)
 public class ODPSTableSource implements BatchTableSource<Row>, ProjectableTableSource<Row> {
 
 	/** odps config */

--- a/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/ODPSTableSourceConverter.java
+++ b/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/ODPSTableSourceConverter.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.blink.odps;
+
+import org.apache.flink.table.catalog.ExternalCatalogTable;
+import org.apache.flink.table.catalog.TableSourceConverter;
+
+import scala.collection.immutable.Map;
+
+/**
+ * The converter is used to convert {@link ODPSTableSource} to or from {@link ExternalCatalogTable}.
+ */
+public class ODPSTableSourceConverter implements TableSourceConverter<ODPSTableSource> {
+
+	@Override
+	public ODPSTableSource fromExternalCatalogTable(ExternalCatalogTable externalCatalogTable) {
+		Map<String, String> properties = externalCatalogTable.properties();
+		String accessId = properties.getOrElse("accessId", null);
+		String accessKey = properties.getOrElse("accessKey", null);
+		String endpoint = properties.getOrElse("endpoint", null);
+		String project = externalCatalogTable.identifier().database();
+		String table = externalCatalogTable.identifier().table();
+		ODPSTableSource odpsTableSource = ODPSTableSource.builder()
+				.setAccessId(accessId)
+				.setAccessKey(accessKey)
+				.setEndpoint(endpoint)
+				.setProject(project)
+				.setTable(table)
+				.build();
+		return odpsTableSource;
+	}
+
+}

--- a/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/conf/ODPSConf.java
+++ b/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/conf/ODPSConf.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.blink.odps.conf;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.Serializable;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * ODPS client configuration
+ */
+public class ODPSConf implements Serializable {
+
+	private static final long serialVersionUID = -2481720994496434494L;
+
+	private final String accessId;
+	private final String accessKey;
+	private final String endpoint;
+	private final String project;
+
+	public ODPSConf(String accessId, String accessKey, String endpoint, String project) {
+		checkArgument(StringUtils.isNotBlank(accessId), "accessId is whitespace or null!");
+		checkArgument(StringUtils.isNotBlank(accessKey), "accessKey is whitespace or null!");
+		checkArgument(StringUtils.isNotBlank(endpoint), "endpoint is whitespace or null!");
+		checkArgument(StringUtils.isNotBlank(project), "project is whitespace or null! ");
+		this.accessId = accessId;
+		this.accessKey = accessKey;
+		this.endpoint = endpoint;
+		this.project = project;
+	}
+
+	public String getAccessId() {
+		return accessId;
+	}
+
+	public String getAccessKey() {
+		return accessKey;
+	}
+
+	public String getEndpoint() {
+		return endpoint;
+	}
+
+	public String getProject() {
+		return project;
+	}
+
+	@Override
+	public String toString() {
+		return "ODPSConf{" +
+				"accessId='" + accessId + '\'' +
+				", accessKey='" + accessKey + '\'' +
+				", endpoint='" + endpoint + '\'' +
+				", project='" + project + '\'' +
+				'}';
+	}
+}

--- a/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/externalcatalog/OdpsStatsProvider.java
+++ b/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/externalcatalog/OdpsStatsProvider.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.blink.odps.externalcatalog;
+
+import com.aliyun.odps.Odps;
+import com.aliyun.odps.OdpsException;
+import com.aliyun.odps.PartitionSpec;
+import com.aliyun.odps.Table;
+import com.aliyun.odps.tunnel.TableTunnel;
+import com.aliyun.odps.tunnel.TunnelException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.table.plan.stats.ColumnStats;
+import org.apache.flink.table.plan.stats.TablePartitionStats;
+import org.apache.flink.table.plan.stats.TableStats;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * This class is responsible for providing statistics for Odps table and Odps partition.
+ * Note: Only support rowCount currently.
+ */
+public class OdpsStatsProvider {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(OdpsStatsProvider.class);
+	private final Odps odps;
+	private final TableTunnel tunnel;
+	private static final int MAX_RETRY_TIMES = 5;
+
+	public OdpsStatsProvider(Odps odps) {
+		this.odps = odps;
+		this.tunnel = new TableTunnel(odps);
+	}
+
+	/**
+	 * request statistics of Odps table
+	 * Note:
+	 * a RuntimeException will happen if catch OdpsException or TunnelException
+	 *
+	 * @param project project name
+	 * @param table   table name
+	 * @return table statistics.
+	 */
+	public TableStats requestStatsOfNonPartitionTable(String project, String table) {
+		checkArgument(
+				StringUtils.isNotBlank(project),
+				"input project cannot be whitespace or null!");
+		checkArgument(
+				StringUtils.isNotBlank(table),
+				"input table cannot be whitespace or null!");
+		Table odpsTable = odps.tables().get(project, table);
+		checkArgument(!odpsTable.isVirtualView(), "View is not supported yet!");
+		TableTunnel.DownloadSession downloadSession =
+				retryableCreateDownLoadSession(project, table, null);
+		long rowCount = downloadSession.getRecordCount();
+		TableStats stats = new TableStats(rowCount, new HashMap<String, ColumnStats>());
+		return stats;
+	}
+
+	/**
+	 * request statistics of Odps table partition
+	 * Note:
+	 * an IllegalArgumentException will happen if the table is not a partitioned table or partition
+	 * specification is invalid.
+	 * a RuntimeException will happen if catch OdpsException or TunnelException
+	 *
+	 * @param project       project name
+	 * @param table         table name
+	 * @param partitionSpec partition specification
+	 * @return partition statistics.
+	 */
+	public TablePartitionStats requestStatsOfTablePartition(
+			String project,
+			String table,
+			PartitionSpec partitionSpec)
+	{
+		checkArgument(
+				StringUtils.isNotBlank(project),
+				"input project cannot be whitespace or null!");
+		checkArgument(
+				StringUtils.isNotBlank(table),
+				"input table cannot be whitespace or null!");
+		checkNotNull(partitionSpec, "input partition specification cannot be null!");
+		Table odpsTable = odps.tables().get(project, table);
+		try {
+			checkArgument(odpsTable.isPartitioned(), "The table is not a partitioned table!");
+		} catch (OdpsException e) {
+			logAndPropagateException(e, "Fail to get odps table %s.%s", project, table);
+		}
+		try {
+			checkArgument(odpsTable.hasPartition(partitionSpec),
+					"The specified partitionspec is not valid!");
+		} catch (OdpsException e) {
+			logAndPropagateException(e,
+					"Fail to get partition %s of odps table %s.%s",
+					partitionSpec.toString(), project, table);
+		}
+		TableTunnel.DownloadSession downloadSession =
+				retryableCreateDownLoadSession(project, table, partitionSpec);
+		long rowCount = downloadSession.getRecordCount();
+		TablePartitionStats stats = new TablePartitionStats(
+				rowCount, new HashMap<String, ColumnStats>());
+		return stats;
+	}
+
+	private TableTunnel.DownloadSession retryableCreateDownLoadSession(
+			String project,
+			String table,
+			PartitionSpec partitionSpec)
+	{
+		int tryTimes = 0;
+		while (true) {
+			try {
+				TableTunnel.DownloadSession downloadSession = null;
+				if (partitionSpec == null) {
+					downloadSession = tunnel.createDownloadSession(
+							project,
+							table);
+				} else {
+					downloadSession = tunnel.createDownloadSession(
+							project,
+							table,
+							partitionSpec);
+				}
+				return downloadSession;
+			} catch (TunnelException e) {
+				String downloadObjectStr = null;
+				if (partitionSpec == null) {
+					downloadObjectStr = String.format("odps table [%s].[%s]!", project, table);
+				} else {
+					downloadObjectStr = String.format("partition [%s] of odps table [%s].[%s]!",
+							partitionSpec.toString(),
+							project,
+							table);
+				}
+				if (tryTimes++ >= MAX_RETRY_TIMES) {
+					logAndPropagateException(e,
+							"Give up to create download session of %s after try %d times",
+							downloadObjectStr,
+							MAX_RETRY_TIMES);
+				} else {
+					LOGGER.warn("Retry to create download session of {} after try {} times",
+							downloadObjectStr,
+							tryTimes, e);
+					try {
+						TimeUnit.SECONDS.sleep(tryTimes);
+					} catch (InterruptedException ie) {
+						logAndPropagateException(ie,
+								"Stop to create download session of %s because of interruption",
+								downloadObjectStr);
+					}
+				}
+			}
+		}
+	}
+
+	private void logAndPropagateException(Throwable t, String format, Object... arguments) {
+		String warnMsg = String.format(format, arguments);
+		LOGGER.warn(warnMsg, t);
+		throw new RuntimeException(warnMsg, t);
+	}
+}

--- a/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/externalcatalog/PartitionSpecConverter.java
+++ b/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/externalcatalog/PartitionSpecConverter.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.blink.odps.externalcatalog;
+
+import com.aliyun.odps.PartitionSpec;
+
+import scala.Predef;
+import scala.Tuple2;
+import scala.collection.JavaConversions;
+import scala.collection.JavaConverters;
+import scala.collection.immutable.Map;
+
+import java.util.LinkedHashMap;
+
+/**
+ * The converter is used to convert PartitionSpec of {@link org.apache.flink.table.catalog.ExternalCatalogTablePartition}
+ * to or from Odps {@link PartitionSpec}.
+ */
+public class PartitionSpecConverter {
+
+	private PartitionSpecConverter() {
+
+	}
+
+	/**
+	 * convert PartitionSpec of ExternalCatalogTablePartition to Odps PartitionSpec
+	 *
+	 * @param partSpecMap
+	 * @return
+	 */
+	public static PartitionSpec fromMap(Map<String, String> partSpecMap) {
+		PartitionSpec odpsPartitionSpec = new PartitionSpec();
+		java.util.Map<String, String> jPartSpec = JavaConversions.asJavaMap(partSpecMap);
+		for (java.util.Map.Entry<String, String> partValue : jPartSpec.entrySet()) {
+			odpsPartitionSpec.set(partValue.getKey(), partValue.getValue());
+		}
+		return odpsPartitionSpec;
+	}
+
+	/**
+	 * convert Odps PartitionSpec to PartitionSpec of ExternalCatalogTablePartition
+	 *
+	 * @param partSpec
+	 * @return
+	 */
+	public static Map<String, String> toMap(PartitionSpec partSpec) {
+		java.util.Map<String, String> partitionMap = new LinkedHashMap<>();
+		for (String key : partSpec.keys()) {
+			partitionMap.put(key, partSpec.get(key));
+		}
+		return JavaConverters.mapAsScalaMapConverter(partitionMap)
+				.asScala()
+				.toMap(Predef.<Tuple2<String, String>>conforms());
+	}
+
+}

--- a/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/externalcatalog/ReadonlyOdpsExternalCatalog.java
+++ b/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/externalcatalog/ReadonlyOdpsExternalCatalog.java
@@ -1,0 +1,344 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.blink.odps.externalcatalog;
+
+import com.alibaba.blink.odps.schema.ODPSColumn;
+import com.alibaba.blink.odps.schema.ODPSTableSchema;
+import com.alibaba.blink.odps.type.ODPSType;
+import com.alibaba.blink.odps.util.ODPSUtil;
+import com.aliyun.odps.Group;
+import com.aliyun.odps.NoSuchObjectException;
+import com.aliyun.odps.Odps;
+import com.aliyun.odps.OdpsException;
+import com.aliyun.odps.Partition;
+import com.aliyun.odps.PartitionSpec;
+import com.aliyun.odps.Project;
+import com.aliyun.odps.Table;
+import com.aliyun.odps.TableSchema;
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterators;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.api.DatabaseNotExistException;
+import org.apache.flink.table.catalog.DataSchema;
+import org.apache.flink.table.catalog.ExternalCatalog;
+import org.apache.flink.table.catalog.ExternalCatalogDatabase;
+import org.apache.flink.table.catalog.ExternalCatalogTable;
+import org.apache.flink.table.catalog.ExternalCatalogTablePartition;
+import org.apache.flink.table.catalog.TableIdentifier;
+import org.apache.flink.table.plan.stats.TablePartitionStats;
+import org.apache.flink.table.plan.stats.TableStats;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import scala.Predef;
+import scala.Tuple2;
+import scala.collection.JavaConversions;
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
+import scala.collection.immutable.Map;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * This class is responsible for connect odps as {@link ExternalCatalog}.
+ * Note: it's a read only service, cannot provide create/drop/alter operation of odps
+ * table/database/partition.
+ */
+public class ReadonlyOdpsExternalCatalog implements ExternalCatalog {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ReadonlyOdpsExternalCatalog.class);
+	private final String aliyunAccount;
+	private final Odps odps;
+	private final ImmutableMap<String, String> odpsConf;
+	private final OdpsStatsProvider statsCollector;
+
+	private ReadonlyOdpsExternalCatalog(
+			String accessId,
+			String accessKey,
+			String endpoint,
+			String aliyunAccount)
+	{
+		this.aliyunAccount = aliyunAccount;
+		this.odps = ODPSUtil.initOdps(accessId, accessKey, endpoint, null);
+		odpsConf = ImmutableMap.of(
+				"accessId", accessId,
+				"accessKey", accessKey,
+				"endpoint", endpoint);
+		this.statsCollector = new OdpsStatsProvider(odps);
+	}
+
+	@Override
+	public void createPartition(String dbName, String tableName, ExternalCatalogTablePartition part,
+			boolean ignoreIfExists)
+	{
+		throw new UnsupportedOperationException("Create partition is not supported yet!");
+	}
+
+	@Override
+	public void dropPartition(String dbName, String tableName, Map<String, String> partSpec,
+			boolean ignoreIfNotExists)
+	{
+		throw new UnsupportedOperationException("Drop partition is not supported yet!");
+
+	}
+
+	@Override
+	public void alterPartition(String dbName, String tableName,
+			ExternalCatalogTablePartition part)
+	{
+		throw new UnsupportedOperationException("Alter partition is not supported yet!");
+	}
+
+	@Override
+	public ExternalCatalogTablePartition getPartition(String dbName, String tableName,
+			Map<String, String> partSpec)
+	{
+		PartitionSpec odpsPartitionSpec = PartitionSpecConverter.fromMap(partSpec);
+		TablePartitionStats partitionStats =
+				statsCollector.requestStatsOfTablePartition(dbName, tableName, odpsPartitionSpec);
+		return new ExternalCatalogTablePartition(
+				partSpec,
+				scala.collection.immutable.Map$.MODULE$.<String, String>empty(),
+				scala.Option.apply(partitionStats));
+	}
+
+	@Override
+	public Seq<Map<String, String>> listPartitionSpec(String dbName, String tableName) {
+		Table odpsTable = odps.tables().get(dbName, tableName);
+		// notes: a RuntimeException will happen if the table is not a partitioned table
+		Iterable<Map<String, String>> partitionSpecs = FluentIterable
+				.from(odpsTable.getPartitions())
+				.transform(
+						new Function<Partition, Map<String, String>>() {
+
+							@Override
+							public Map<String, String> apply(Partition partition) {
+								PartitionSpec partitionSpec = partition.getPartitionSpec();
+								return PartitionSpecConverter.toMap(partitionSpec);
+							}
+						});
+		return JavaConversions.asScalaIterable(partitionSpecs).toSeq();
+	}
+
+	@Override
+	public void createTable(ExternalCatalogTable table, boolean ignoreIfExists) {
+		throw new UnsupportedOperationException("Create table is not supported yet!");
+	}
+
+	@Override
+	public void dropTable(String dbName, String tableName, boolean ignoreIfNotExists) {
+		throw new UnsupportedOperationException("Drop table is not supported yet!");
+	}
+
+	@Override
+	public void alterTable(ExternalCatalogTable table) {
+		throw new UnsupportedOperationException("Alter table is not supported yet!");
+	}
+
+	@Override
+	public ExternalCatalogTable getTable(String dbName, String tableName) {
+		Table odpsTable = odps.tables().get(dbName, tableName);
+		TableSchema schema = odpsTable.getSchema();
+		ODPSTableSchema tableSchema =
+				new ODPSTableSchema(
+						schema.getColumns(),
+						schema.getPartitionColumns(),
+						odpsTable.isVirtualView());
+		DataSchema dataSchema = parseOdpsTableTableSchema(tableSchema);
+		Iterable<String> partitionColumns = null;
+		TableStats tableStats = null;
+		if (tableSchema.isPartition() || tableSchema.isView()) {
+			partitionColumns = parsePartitionColumns(tableSchema);
+		} else {
+			partitionColumns = new ArrayList<>();
+			tableStats = this.statsCollector.requestStatsOfNonPartitionTable(dbName, tableName);
+		}
+		ExternalCatalogTable table = new ExternalCatalogTable(
+				new TableIdentifier(dbName, tableName),
+				"odps",
+				dataSchema,
+				JavaConverters.mapAsScalaMapConverter(odpsConf).asScala().toMap(
+						Predef.<Tuple2<String, String>>conforms()
+				),
+				scala.Option.apply(tableStats),
+				scala.Option.<String>empty(),
+				JavaConversions.asScalaIterable(partitionColumns).toSeq(),
+				tableSchema.isPartition(),
+				odpsTable.getCreatedTime().getTime(),
+				-1
+		);
+		return table;
+	}
+
+	@Override
+	public Seq<String> listTables(String dbName) {
+		// notes: a RuntimeException will happen if has no privilege 'odps:List' on the project
+		Iterator<String> tables = Iterators.transform(odps.tables().iterator(dbName),
+				new Function<Table, String>() {
+					@Override
+					public String apply(Table table) {
+						return table.getName();
+					}
+				});
+		return JavaConversions.asScalaIterator(tables).toSeq();
+	}
+
+	@Override
+	public void createDatabase(ExternalCatalogDatabase db, boolean ignoreIfExists) {
+		throw new UnsupportedOperationException("Create database is not supported yet!");
+	}
+
+	@Override
+	public void dropDatabase(String dbName, boolean ignoreIfNotExists) {
+		throw new UnsupportedOperationException("Drop database is not supported yet!");
+	}
+
+	@Override
+	public void alterDatabase(ExternalCatalogDatabase db) {
+		throw new UnsupportedOperationException("Alter database is not supported yet!");
+	}
+
+	@Override
+	public ExternalCatalogDatabase getDatabase(String dbName) {
+		try {
+			Project p = odps.projects().get(dbName);
+			p.reload();
+			return new ExternalCatalogDatabase(dbName,
+					JavaConverters.mapAsScalaMapConverter(p.getProperties()).asScala().toMap(
+							Predef.<Tuple2<String, String>>conforms()
+					));
+		} catch (NoSuchObjectException e) {
+			LOGGER.warn("no such project {}", dbName, e);
+			throw new DatabaseNotExistException(dbName, e);
+		} catch (OdpsException e) {
+			LOGGER.warn("error happened when get project {}", dbName, e);
+			throw new RuntimeException("error happened when get project " + dbName, e);
+		}
+	}
+
+	/**
+	 * @return If aliyunAccount is null, return all odps project lists;
+	 * else return odps project lists which account has privilege on
+	 */
+	@Override
+	public Seq<String> listDatabases() {
+		Iterator<Project> projectItr = Group.getProjects(null, null, aliyunAccount, odps);
+		Set<String> projectNames = new LinkedHashSet<>();
+		while (projectItr.hasNext()) {
+			Project p = projectItr.next();
+			projectNames.add(p.getName());
+		}
+		return JavaConversions.asScalaIterable(projectNames).toSeq();
+	}
+
+	private DataSchema parseOdpsTableTableSchema(ODPSTableSchema tableSchema) {
+		int columnsNum = tableSchema.getColumns().size();
+		String[] returnFieldsName = new String[columnsNum];
+		TypeInformation<?>[] returnFieldsType = new TypeInformation<?>[columnsNum];
+		for (int idx = 0; idx < columnsNum; idx++) {
+			ODPSColumn column = tableSchema.getColumns().get(idx);
+			returnFieldsName[idx] = column.getName();
+			returnFieldsType[idx] = ODPSType.valueOf(column.getType().name()).toFlinkType();
+		}
+		return new DataSchema(returnFieldsType, returnFieldsName);
+	}
+
+	private Iterable<String> parsePartitionColumns(ODPSTableSchema schema) {
+		return FluentIterable.from(schema.getColumns())
+				.filter(new Predicate<ODPSColumn>() {
+					@Override
+					public boolean apply(@Nullable ODPSColumn column) {
+						return column.isPartition();
+					}
+				})
+				.transform(new Function<ODPSColumn, String>() {
+					@Override
+					public String apply(ODPSColumn column) {
+						return column.getName();
+					}
+				});
+	}
+
+	public static class Builder {
+		// required params
+		private String accessId;
+		private String accessKey;
+		private String endpoint;
+		// optional params
+		private String aliyunAccount;
+
+		public Builder() {
+
+		}
+
+		public Builder setAccessId(String accessId) {
+			checkArgument(
+					StringUtils.isNotBlank(accessId),
+					"input accessId cannot be whitespace or null!");
+			this.accessId = accessId;
+			return this;
+		}
+
+		public Builder setAccessKey(String accessKey) {
+			checkArgument(
+					StringUtils.isNotBlank(accessKey),
+					"input accessKey cannot be whitespace or null!");
+			this.accessKey = accessKey;
+			return this;
+		}
+
+		public Builder setEndpoint(String endpoint) {
+			checkArgument(
+					StringUtils.isNotBlank(endpoint),
+					"input endpoint cannot be whitespace or null!");
+			this.endpoint = endpoint;
+			return this;
+		}
+
+		public Builder setAliyunAccount(String aliyunAccount) {
+			checkArgument(
+					StringUtils.isNotBlank(aliyunAccount),
+					"input aliyunAccount cannot be whitespace or null!");
+			this.aliyunAccount = aliyunAccount;
+			return this;
+		}
+
+		public ReadonlyOdpsExternalCatalog build() {
+			checkNotNull(accessId, "accessId cannot be null!");
+			checkNotNull(accessKey, "accessKey cannot be null!");
+			checkNotNull(endpoint, "endpoint cannot be null!");
+			return new ReadonlyOdpsExternalCatalog(
+					accessId,
+					accessKey,
+					endpoint,
+					aliyunAccount);
+		}
+	}
+}

--- a/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/inputformat/ODPSInputFormat.java
+++ b/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/inputformat/ODPSInputFormat.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.blink.odps.inputformat;
+
+import com.alibaba.blink.odps.conf.ODPSConf;
+import com.alibaba.blink.odps.schema.ODPSColumn;
+import com.alibaba.blink.odps.schema.ODPSTableSchema;
+import com.alibaba.blink.odps.type.ODPSType;
+import com.aliyun.odps.PartitionSpec;
+import com.aliyun.odps.data.Record;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.types.Row;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+
+@Internal
+public class ODPSInputFormat extends ODPSInputFormatBase<Row> {
+
+	public ODPSInputFormat(ODPSConf odpsConf, String table, String[] selectedColumns,
+			ODPSTableSchema tableSchema, @Nullable String[] partitions)
+	{
+		super(odpsConf, table, selectedColumns, tableSchema, partitions);
+	}
+
+	@Override
+	protected Row convertRecord(Record record, PartitionSpec partitionSpec,
+			Row reuse) throws IOException
+	{
+		for (int idx = 0; idx < selectedColumns.length; idx++) {
+			String columnName = selectedColumns[idx];
+			ODPSColumn column = odpsTableSchema.getColumn(columnName);
+			ODPSType odpsType = ODPSType.valueOf(column.getType().name());
+			if (column.isPartition()) {
+				odpsType.setRowField(reuse, idx, partitionSpec.get(columnName));
+			} else {
+				odpsType.setRowField(reuse, idx, record, columnName);
+			}
+		}
+		return reuse;
+	}
+}

--- a/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/inputformat/ODPSInputFormatBase.java
+++ b/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/inputformat/ODPSInputFormatBase.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.blink.odps.inputformat;
+
+import com.alibaba.blink.odps.conf.ODPSConf;
+import com.alibaba.blink.odps.schema.ODPSTableSchema;
+import com.alibaba.blink.odps.split.ODPSInputSplit;
+import com.alibaba.blink.odps.split.ODPSPartitionSegmentDownloadDesc;
+import com.alibaba.blink.odps.stat.ODPSStatistics;
+import com.alibaba.blink.odps.util.ElementSplitUtil;
+import com.alibaba.blink.odps.util.ODPSUtil;
+import com.aliyun.odps.Odps;
+import com.aliyun.odps.PartitionSpec;
+import com.aliyun.odps.data.Record;
+import com.aliyun.odps.tunnel.TableTunnel;
+import com.aliyun.odps.tunnel.TunnelException;
+import com.google.common.collect.Iterables;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.io.DefaultInputSplitAssigner;
+import org.apache.flink.api.common.io.RichInputFormat;
+import org.apache.flink.api.common.io.statistics.BaseStatistics;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.io.InputSplitAssigner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+@Internal
+public abstract class ODPSInputFormatBase<T> extends RichInputFormat<T, ODPSInputSplit> {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ODPSInputFormatBase.class);
+
+	private final ODPSConf odpsConf;
+
+	private final String table;
+
+	/** partition to prune */
+	private final String[] partitions;
+
+	/** columns to prune */
+	protected final String[] selectedColumns;
+
+	/** odps table schema information */
+	protected final ODPSTableSchema odpsTableSchema;
+
+	private Tuple2<String[], long[]> downloadSessionsAndCounts;
+
+	private transient ODPSInputSplitReader reader;
+
+	private transient TableTunnel tableTunnel;
+
+
+	public ODPSInputFormatBase(ODPSConf odpsConf, String table, String[] selectedColumns,
+			ODPSTableSchema tableSchema, @Nullable String[] partitions)
+	{
+		this.odpsConf = checkNotNull(odpsConf);
+		checkArgument(ArrayUtils.isNotEmpty(selectedColumns),
+				"input selected columns cannot be null or empty! ");
+		this.selectedColumns = selectedColumns;
+		checkArgument(StringUtils.isNotBlank(table), "table is whitespace or null! ");
+		checkArgument(!tableSchema.isPartition() || partitions != null,
+				"partitions cannot be null for partition table !");
+		this.odpsTableSchema = tableSchema;
+		this.table = table;
+		this.partitions = partitions;
+	}
+
+	@Override
+	public void configure(Configuration parameters) {
+		// TODO
+	}
+
+	@Override
+	public BaseStatistics getStatistics(BaseStatistics cachedStatistics) throws IOException {
+		final ODPSStatistics cachedStats =
+				(cachedStatistics != null && cachedStatistics instanceof ODPSStatistics) ?
+						(ODPSStatistics) cachedStatistics : null;
+		try {
+			long dataLastModTime = 0;
+			if (!odpsTableSchema.isPartition()) {
+				long tableDataLastModTime = ODPSUtil.getTableLastModifyTime(odpsConf, table);
+				dataLastModTime = Math.max(tableDataLastModTime, dataLastModTime);
+			} else {
+				for (String partition : partitions) {
+					long partitionDataLastModTime =
+							ODPSUtil.getPartitionLastModifyTime(odpsConf, table, partition);
+					dataLastModTime = Math.max(partitionDataLastModTime, dataLastModTime);
+				}
+			}
+			// if data didn't changed since last time, return last statistics
+			if (cachedStats != null && dataLastModTime <= cachedStats.getDataLastModTime()) {
+				return cachedStats;
+			}
+
+			long totalSize = 0;
+			if (!odpsTableSchema.isPartition()) {
+				totalSize = ODPSUtil.getTableSize(odpsConf, table);
+			} else {
+				for (String partition : partitions) {
+					totalSize += ODPSUtil.getPartitionSize(odpsConf, table, partition);
+				}
+			}
+
+			setDownloadSessionAndCountIfAbsent();
+			long[] numberOfRecords = downloadSessionsAndCounts.f1;
+			long totalNumberOfRecords = 0;
+			for (long nums : numberOfRecords) {
+				totalNumberOfRecords += nums;
+			}
+
+			return new ODPSStatistics(totalSize, totalNumberOfRecords, dataLastModTime);
+		} catch (Throwable t) {
+			LOGGER.error("fail to get statistics of odps table [{}]", table, t);
+			// no statistics available
+			return null;
+		}
+	}
+
+	@Override
+	public void openInputFormat() {
+		// called once per inputFormat (on open) on DataSourceTask
+		Odps odps = ODPSUtil.initOdps(odpsConf);
+		this.tableTunnel = new TableTunnel(odps);
+	}
+
+	@Override
+	public void closeInputFormat() {
+		tableTunnel = null;
+	}
+
+	@Override
+	public ODPSInputSplit[] createInputSplits(int minNumSplits) throws IOException {
+		checkArgument(minNumSplits >= 1, "splits num cannot be less than 1!");
+		int numSplits = minNumSplits;
+		// divide total count into numSplits parts
+		// maybe one task would process more than one partition segment
+		setDownloadSessionAndCountIfAbsent();
+		long[] counts = downloadSessionsAndCounts.f1;
+		ElementSplitUtil.ElementSegment[][] splitsResult = ElementSplitUtil
+				.doSplit(counts, numSplits);
+		assert splitsResult.length == numSplits;
+		String[] sessionIds = downloadSessionsAndCounts.f0;
+		ODPSInputSplit[] splits = new ODPSInputSplit[numSplits];
+		for (int splitIdx = 0; splitIdx < numSplits; splitIdx++) {
+			ElementSplitUtil.ElementSegment[] segmentsInOneSplit = splitsResult[splitIdx];
+			List<ODPSPartitionSegmentDownloadDesc> partitionSegments =
+					new ArrayList<>(segmentsInOneSplit.length);
+			for (int segmentIdx = 0; segmentIdx < segmentsInOneSplit.length; segmentIdx++) {
+				ElementSplitUtil.ElementSegment segment = segmentsInOneSplit[segmentIdx];
+				// filter segment which count is less than 0
+				if(segment.getCount() <= 0) {
+					continue;
+				}
+				int partitionId = segment.getElementId();
+				String partition = odpsTableSchema.isPartition() ? partitions[partitionId] : null;
+				String sessionId = sessionIds[partitionId];
+				partitionSegments.add(new ODPSPartitionSegmentDownloadDesc(
+						partition, segment.getStart(), segment.getCount(), sessionId));
+			}
+			splits[splitIdx] = new ODPSInputSplit(splitIdx,
+					Iterables.toArray(partitionSegments, ODPSPartitionSegmentDownloadDesc.class));
+		}
+		return splits;
+	}
+
+	@Override
+	public InputSplitAssigner getInputSplitAssigner(ODPSInputSplit[] inputSplits) {
+		return new DefaultInputSplitAssigner(inputSplits);
+	}
+
+	@Override
+	public void open(ODPSInputSplit split) throws IOException {
+		this.reader = new ODPSInputSplitReader(split, this.selectedColumns, odpsTableSchema,
+				tableTunnel, this.odpsConf.getProject(), table);
+	}
+
+	@Override
+	public boolean reachedEnd() throws IOException {
+		return !this.reader.hasNext();
+	}
+
+	@Override
+	public T nextRecord(T reuse) throws IOException {
+		Tuple2<Record, PartitionSpec> columnContent = this.reader.next();
+		if (columnContent == null) {
+			IOUtils.closeQuietly(this.reader);
+			return null;
+		} else {
+			return convertRecord(columnContent.f0, columnContent.f1, reuse);
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (this.reader != null) {
+			IOUtils.closeQuietly(this.reader);
+		}
+	}
+
+	/**
+	 * convert ODPS record instance to specify T type
+	 *
+	 * @param record        record instance, not including partition column value
+	 * @param partitionSpec partition spec of this record
+	 * @param reuse         reuse data
+	 * @return converted data
+	 * @throws IOException
+	 */
+	protected abstract T convertRecord(Record record, PartitionSpec partitionSpec,
+			T reuse) throws IOException;
+
+	/**
+	 * get record count of each partition or table and save session id
+	 *
+	 * @return
+	 * @throws IOException
+	 */
+	private void setDownloadSessionAndCountIfAbsent() throws IOException {
+		if (this.downloadSessionsAndCounts != null) {
+			return;
+		}
+		Odps odps = ODPSUtil.initOdps(odpsConf);
+		TableTunnel tunnel = new TableTunnel(odps);
+		String project = odpsConf.getProject();
+		if (!odpsTableSchema.isPartition()) {
+			try {
+				TableTunnel.DownloadSession downloadSession =
+						tunnel.createDownloadSession(project, table);
+				this.downloadSessionsAndCounts = new Tuple2<>(new String[]{downloadSession.getId()},
+						new long[]{downloadSession.getRecordCount()});
+			} catch (TunnelException e) {
+				LOGGER.warn("fail to create download session to table [{}] in project [{}]",
+						project, e);
+				throw new IOException("fail to create download session to odps table", e);
+			}
+		} else {
+			int partitionSize = partitions.length;
+			String[] sessionIds = new String[partitionSize];
+			long[] counts = new long[partitionSize];
+			for (int partitionIdx = 0; partitionIdx < partitionSize; partitionIdx++) {
+				try {
+					PartitionSpec partitionSpec = new PartitionSpec(partitions[partitionIdx]);
+					TableTunnel.DownloadSession downloadSession =
+							tunnel.createDownloadSession(project, table, partitionSpec);
+					sessionIds[partitionIdx] = downloadSession.getId();
+					counts[partitionIdx] = downloadSession.getRecordCount();
+				} catch (TunnelException e) {
+					LOGGER.warn("fail to create download session to partition [{}] on table [{}] " +
+							"in project [{}]", partitions[partitionIdx], table, project, e);
+					throw new IOException("fail to create download session to odps table", e);
+				}
+			}
+			this.downloadSessionsAndCounts = new Tuple2<>(sessionIds, counts);
+		}
+	}
+}
+
+

--- a/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/inputformat/ODPSInputSplitReader.java
+++ b/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/inputformat/ODPSInputSplitReader.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.blink.odps.inputformat;
+
+import com.alibaba.blink.odps.schema.ODPSColumn;
+import com.alibaba.blink.odps.schema.ODPSTableSchema;
+import com.alibaba.blink.odps.split.ODPSInputSplit;
+import com.alibaba.blink.odps.split.ODPSPartitionSegmentDownloadDesc;
+import com.aliyun.odps.Column;
+import com.aliyun.odps.PartitionSpec;
+import com.aliyun.odps.data.Record;
+import com.aliyun.odps.tunnel.TableTunnel;
+import com.aliyun.odps.tunnel.TunnelException;
+import com.aliyun.odps.tunnel.io.TunnelRecordReader;
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import org.apache.commons.io.IOUtils;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * A reader to read the content of an odps inputSplit
+ */
+@Internal
+public class ODPSInputSplitReader implements Closeable {
+
+	private final static Logger LOGGER = LoggerFactory.getLogger(ODPSInputSplitReader.class);
+
+	private final ODPSPartitionSegmentDownloadDesc[] partSegments;
+
+	private final List<Column> odpsColumns;
+
+	private final TableTunnel tableTunnel;
+
+	private final String project;
+
+	private final String table;
+
+	private TunnelRecordReader recordReader;
+
+	private int currentPartSegmentIdx;
+
+	private ODPSPartitionSegmentDownloadDesc currentPartitionDownloadDesc;
+
+	private PartitionSpec currentPartitionSpec;
+
+	private boolean reachEnd;
+
+	private int position;
+
+	private final int MAX_RETRY_NUMBER = 3;
+
+	/**
+	 * create a special reader instance to read the content of an odps inputSplit
+	 *
+	 * @param split
+	 * @param selectedColumns
+	 * @param tableTunnel
+	 * @param project
+	 * @param table
+	 */
+	public ODPSInputSplitReader(
+			ODPSInputSplit split, String[] selectedColumns,
+			final ODPSTableSchema tableSchema, TableTunnel tableTunnel, String project,
+			final String table)
+	{
+		this.partSegments = split.getPartitions();
+		// filter partition column
+		this.odpsColumns = FluentIterable.of(selectedColumns)
+				.filter(new Predicate<String>() {
+					@Override
+					public boolean apply(@Nullable String columnName) {
+						return !tableSchema.isPartitionColumn(columnName);
+					}
+				}).transform(new Function<String, Column>() {
+					@Override
+					public Column apply(String columnName) {
+						ODPSColumn column = tableSchema.getColumn(columnName);
+						return new Column(column.getName(), column.getType());
+					}
+				}).toList();
+		this.tableTunnel = tableTunnel;
+		this.project = project;
+		this.table = table;
+		reachEnd = false;
+		currentPartSegmentIdx = -1;
+		position = 0;
+		openNextPartSegment();
+	}
+
+	/**
+	 * whether has next element of current reader
+	 *
+	 * @return true if has next element, else return false
+	 */
+	public boolean hasNext() {
+		return !reachEnd;
+	}
+
+	/**
+	 * return next element
+	 *
+	 * @return a tuple contain two elements, first is record value of normal columns, second is
+	 * partition spec which holds value of partition columns
+	 * @throws IOException
+	 */
+	public Tuple2<Record, PartitionSpec> next() throws IOException {
+		Record record = null;
+		try {
+			record = recordReader.read();
+			++position;
+		} catch (IOException ioe) {
+			LOGGER.warn("Occur Odps record reader issues, reconnect", ioe);
+			// reconnect from position
+			recordReader = createRecordReader();
+			return next();
+		}
+
+		if (record != null) {
+			return Tuple2.of(record, currentPartitionSpec);
+		} else {
+			IOUtils.closeQuietly(recordReader);
+			if (openNextPartSegment()) {
+				return next();
+			} else {
+				// no partition segment left to read
+				return null;
+			}
+		}
+	}
+
+	@Override
+	public void close() {
+		if (recordReader != null) {
+			IOUtils.closeQuietly(recordReader);
+			recordReader = null;
+		}
+	}
+
+	private TunnelRecordReader createRecordReader() {
+		int retries = 0;
+		while (true) {
+			if (retries++ >= MAX_RETRY_NUMBER) {
+				LOGGER.warn("reach max retries limit to open record reader");
+				throw new RuntimeException(
+						"fail to open odps record reader of table for " + MAX_RETRY_NUMBER + "times"
+				);
+			}
+
+			try {
+				TableTunnel.DownloadSession downloadSession = null;
+				if (currentPartitionSpec == null) {
+					downloadSession = tableTunnel.getDownloadSession(
+							project,
+							table,
+							currentPartitionDownloadDesc.getDownloadSessionID());
+				} else {
+					downloadSession = tableTunnel.getDownloadSession(
+							project,
+							table,
+							currentPartitionSpec,
+							currentPartitionDownloadDesc.getDownloadSessionID());
+				}
+				return downloadSession.openRecordReader(
+						currentPartitionDownloadDesc.getStart() + position,
+						currentPartitionDownloadDesc.getCount() - position,
+						true,
+						odpsColumns);
+			} catch (TunnelException | IOException e) {
+				if (currentPartitionSpec == null) {
+					LOGGER.warn("fail to open record reader of odps table [{}]", table);
+				} else {
+					LOGGER.warn(
+							"fail to open record reader of odps table [{}] on partition [{}]",
+							table,
+							currentPartitionSpec.toString());
+				}
+
+				try {
+					Thread.sleep(1000 * retries);
+				} catch (InterruptedException ie) {
+					LOGGER.warn("fail to open record reader of table", ie);
+					throw new RuntimeException("fail to open record reader of table", ie);
+				}
+			}
+		}
+	}
+
+	/**
+	 * try to read next partition segment
+	 *
+	 * @return true if open next partition segment, false if there is no next partition segment
+	 */
+	private boolean openNextPartSegment() {
+		if (currentPartSegmentIdx == partSegments.length - 1) {
+			reachEnd = true;
+			return false;
+		} else {
+			currentPartitionDownloadDesc = partSegments[++currentPartSegmentIdx];
+			currentPartitionSpec = currentPartitionDownloadDesc.getPartitionSpec();
+			// skip empty segment
+			if (currentPartitionDownloadDesc.getCount() != 0) {
+				position = 0;
+				recordReader = createRecordReader();
+				return true;
+			} else {
+				return openNextPartSegment();
+			}
+		}
+	}
+
+}
+

--- a/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/schema/ODPSColumn.java
+++ b/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/schema/ODPSColumn.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.blink.odps.schema;
+
+import com.aliyun.odps.OdpsType;
+
+import java.io.Serializable;
+
+/**
+ * column information including name, type, isPartition trait
+ */
+public class ODPSColumn implements Serializable {
+	private static final long serialVersionUID = 3385061492593160182L;
+	private final String name;
+	private final OdpsType type;
+	private final boolean isPartition;
+
+	public ODPSColumn(String name, OdpsType type) {
+		this(name, type, false);
+	}
+
+	public ODPSColumn(String name, OdpsType type, boolean isPartition) {
+		this.name = name;
+		this.type = type;
+		this.isPartition = isPartition;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public OdpsType getType() {
+		return type;
+	}
+
+	public boolean isPartition() {
+		return isPartition;
+	}
+
+	@Override
+	public String toString() {
+		return "ODPSColumn{" +
+				"name='" + name + '\'' +
+				", type=" + type +
+				", isPartition=" + isPartition +
+				'}';
+	}
+}

--- a/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/schema/ODPSTableSchema.java
+++ b/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/schema/ODPSTableSchema.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.blink.odps.schema;
+
+import com.aliyun.odps.Column;
+import com.google.common.base.Function;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.Maps;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * ODPS table schema information including column information and isPartition table
+ */
+public class ODPSTableSchema implements Serializable {
+	private static final long serialVersionUID = -6327923765714170499L;
+
+	private final List<ODPSColumn> columns;
+
+	private final boolean isPartition;
+
+	private final boolean isView;
+
+	private transient Map<String, ODPSColumn> columnMap;
+
+	public ODPSTableSchema(
+			List<Column> normalColumns,
+			List<Column> partitionColumns,
+			boolean isView) {
+
+		checkArgument(
+				normalColumns != null && !normalColumns.isEmpty(),
+				"input normal columns cannot be null or empty!");
+		FluentIterable<ODPSColumn> columnList = FluentIterable.from(normalColumns)
+				.transform(new Function<Column, ODPSColumn>() {
+					@Override
+					public ODPSColumn apply(Column column) {
+						return new ODPSColumn(
+								column.getName(),
+								column.getType());
+					}
+				});
+		this.isView = isView;
+
+		boolean hasPartitionCols = partitionColumns != null && !partitionColumns.isEmpty();
+
+		if (hasPartitionCols) {
+			columnList = columnList.append(
+					FluentIterable.from(partitionColumns)
+							.transform(new Function<Column, ODPSColumn>() {
+								@Override
+								public ODPSColumn apply(Column column) {
+									return new ODPSColumn(
+											column.getName(),
+											column.getType(),
+											true);
+								}
+							}));
+		}
+		isPartition = !isView && hasPartitionCols;
+		this.columns = columnList.toList();
+		rebuildColumnMap();
+	}
+
+	public List<ODPSColumn> getColumns() {
+		return columns;
+	}
+
+	public boolean isPartition() {
+		return isPartition;
+	}
+
+	public boolean isView() {
+		return isView;
+	}
+
+	public ODPSColumn getColumn(String name) {
+		return columnMap.get(name);
+	}
+
+	public boolean isPartitionColumn(String name) {
+		ODPSColumn column = columnMap.get(name);
+		if (column != null) {
+			return column.isPartition();
+		} else {
+			throw new IllegalArgumentException("unknown column " + name);
+		}
+	}
+
+	private void readObject(ObjectInputStream inputStream) throws IOException,
+			ClassNotFoundException
+	{
+		inputStream.defaultReadObject();
+		rebuildColumnMap();
+	}
+
+	private void rebuildColumnMap() {
+		this.columnMap = Maps.uniqueIndex(columns.iterator(), new Function<ODPSColumn, String>() {
+			@Override
+			public String apply(@Nullable ODPSColumn column) {
+				return column.getName();
+			}
+		});
+	}
+}
+

--- a/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/split/ODPSInputSplit.java
+++ b/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/split/ODPSInputSplit.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.blink.odps.split;
+
+import org.apache.flink.core.io.InputSplit;
+
+import java.util.Arrays;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * input doSplit of odps table
+ */
+public class ODPSInputSplit implements InputSplit {
+
+	private static final long serialVersionUID = -4003215075338027544L;
+
+	private final int splitId;
+	private ODPSPartitionSegmentDownloadDesc[] partitions;
+
+	public ODPSInputSplit(int splitId, ODPSPartitionSegmentDownloadDesc... partitions) {
+		checkArgument(splitId >= 0, "splitId is less than zero!");
+		this.splitId = splitId;
+		this.partitions = checkNotNull(partitions, "partitions is null!");
+	}
+
+	@Override
+	public int getSplitNumber() {
+		return splitId;
+	}
+
+
+	public ODPSPartitionSegmentDownloadDesc[] getPartitions() {
+		return partitions;
+	}
+
+	@Override
+	public String toString() {
+		return "ODPSInputSplit{" +
+				"splitId=" + splitId +
+				", partitions=" + Arrays.toString(partitions) +
+				'}';
+	}
+}

--- a/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/split/ODPSPartitionSegmentDownloadDesc.java
+++ b/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/split/ODPSPartitionSegmentDownloadDesc.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.blink.odps.split;
+
+
+import com.aliyun.odps.PartitionSpec;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * a description of an odps partition download
+ */
+public class ODPSPartitionSegmentDownloadDesc implements Serializable {
+	private static final long serialVersionUID = -3786613257670817735L;
+	/** specify a odps partition */
+	private final String partition;
+
+	private transient PartitionSpec partitionSpec;
+
+	/** start location to download of a odps partition */
+	private final long start;
+
+	/** count to download from a odps partition */
+	private final long count;
+
+	/** download session */
+	private String downloadSessionID;
+
+	public ODPSPartitionSegmentDownloadDesc(@Nullable String partition, long start, long count,
+			String downloadSessionID)
+	{
+		checkArgument(StringUtils.isNotBlank(downloadSessionID),
+				"downloadSessionID is whitespace or null!");
+		checkArgument(start >= 0, "start is less than zero!");
+		checkArgument(count > 0, "count is not bigger than zero!");
+		this.partition = partition;
+		buildPartitionSpec();
+		this.start = start;
+		this.count = count;
+		this.downloadSessionID = downloadSessionID;
+	}
+
+	public String getPartition() {
+		return partition;
+	}
+
+	public long getStart() {
+		return start;
+	}
+
+	public long getCount() {
+		return count;
+	}
+
+	public String getDownloadSessionID() {
+		return downloadSessionID;
+	}
+
+	public void setDownloadSessionID(String downloadSessionID) {
+		this.downloadSessionID = downloadSessionID;
+	}
+
+	public PartitionSpec getPartitionSpec() {
+		return partitionSpec;
+	}
+
+	private void readObject(ObjectInputStream inputStream) throws IOException,
+			ClassNotFoundException
+	{
+		inputStream.defaultReadObject();
+		buildPartitionSpec();
+	}
+
+	private void buildPartitionSpec() {
+		this.partitionSpec = partition == null ? null : new PartitionSpec(partition);
+	}
+
+	@Override
+	public String toString() {
+		return "ODPSPartitionSegmentDownloadDesc{" +
+				"partition='" + partition + '\'' +
+				", partitionSpec=" + partitionSpec +
+				", start=" + start +
+				", count=" + count +
+				", downloadSessionID='" + downloadSessionID + '\'' +
+				'}';
+	}
+}

--- a/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/stat/ODPSStatistics.java
+++ b/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/stat/ODPSStatistics.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.blink.odps.stat;
+
+import org.apache.flink.api.common.io.statistics.BaseStatistics;
+
+/**
+ * OPDS Statistics
+ */
+public class ODPSStatistics implements BaseStatistics {
+	/** the total size of the odps input */
+	private final long totalInputSize;
+
+	/** the number of records in the odps input */
+	private final long numberOfRecords;
+
+	/** last modify time of the odps input */
+	private final long dataLastModTime;
+
+	public ODPSStatistics(long totalInputSize, long numberOfRecords, long dataLastModTime) {
+		this.numberOfRecords = numberOfRecords;
+		this.totalInputSize = totalInputSize;
+		this.dataLastModTime = dataLastModTime;
+	}
+
+	@Override
+	public long getTotalInputSize() {
+		return totalInputSize;
+	}
+
+	@Override
+	public long getNumberOfRecords() {
+		return numberOfRecords;
+	}
+
+	@Override
+	public float getAverageRecordWidth() {
+		return totalInputSize / numberOfRecords;
+	}
+
+	public long getDataLastModTime() {
+		return dataLastModTime;
+	}
+}

--- a/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/type/ODPSType.java
+++ b/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/type/ODPSType.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.blink.odps.type;
+
+import com.aliyun.odps.data.Record;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.types.Row;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+
+/**
+ * supported odps column type
+ */
+public enum ODPSType {
+
+	BIGINT {
+		public TypeInformation<?> toFlinkType() {
+			return BasicTypeInfo.LONG_TYPE_INFO;
+		}
+
+		public void setRowField(Row row, int fieldIdx, String valueStr) {
+			long value = valueStr == null ? null : Long.parseLong(valueStr);
+			row.setField(fieldIdx, value);
+		}
+
+		public void setRowField(Row row, int fieldIdx, Record record, String odpsColumnName) {
+			row.setField(fieldIdx, record.getBigint(odpsColumnName));
+		}
+	},
+
+	DOUBLE {
+		public TypeInformation<?> toFlinkType() {
+			return BasicTypeInfo.DOUBLE_TYPE_INFO;
+		}
+
+		public void setRowField(Row row, int fieldIdx, String valueStr) {
+			double value = valueStr == null ? null : Double.parseDouble(valueStr);
+			row.setField(fieldIdx, value);
+		}
+
+		public void setRowField(Row row, int fieldIdx, Record record, String odpsColumnName) {
+			row.setField(fieldIdx, record.getDouble(odpsColumnName));
+		}
+	},
+
+	BOOLEAN {
+		public TypeInformation<?> toFlinkType() {
+			return BasicTypeInfo.BOOLEAN_TYPE_INFO;
+		}
+
+		public void setRowField(Row row, int fieldIdx, String valueStr) {
+			boolean value = valueStr == null ? null : Boolean.parseBoolean(valueStr);
+			row.setField(fieldIdx, value);
+		}
+
+		public void setRowField(Row row, int fieldIdx, Record record, String odpsColumnName) {
+			row.setField(fieldIdx, record.getBoolean(odpsColumnName));
+		}
+	},
+
+	DATETIME {
+		public TypeInformation<?> toFlinkType() {
+			return SqlTimeTypeInfo.DATE;
+		}
+
+		public void setRowField(Row row, int fieldIdx, String valueStr) {
+			// TODO
+		}
+
+		public void setRowField(Row row, int fieldIdx, Record record, String odpsColumnName) {
+			Date value = new Date(record.getDatetime(odpsColumnName).getTime());
+			row.setField(fieldIdx, value);
+		}
+	},
+
+	STRING {
+		public TypeInformation<?> toFlinkType() {
+			return BasicTypeInfo.STRING_TYPE_INFO;
+		}
+
+		public void setRowField(Row row, int fieldIdx, String valueStr) {
+			row.setField(fieldIdx, valueStr);
+		}
+
+		public void setRowField(Row row, int fieldIdx, Record record, String odpsColumnName) {
+			row.setField(fieldIdx, record.getString(odpsColumnName));
+		}
+	},
+
+	DECIMAL {
+		public TypeInformation<?> toFlinkType() {
+			return BasicTypeInfo.BIG_DEC_TYPE_INFO;
+		}
+
+		public void setRowField(Row row, int fieldIdx, String valueStr) {
+			BigDecimal value = valueStr == null ? null : new BigDecimal(valueStr);
+			row.setField(fieldIdx, value);
+		}
+
+		public void setRowField(Row row, int fieldIdx, Record record, String odpsColumnName) {
+			row.setField(fieldIdx, record.getDecimal(odpsColumnName));
+		}
+	},
+
+	MAP {
+		public TypeInformation<?> toFlinkType() {
+			throw new UnsupportedOperationException("unknown column type " + toString());
+		}
+
+		public void setRowField(Row row, int fieldIdx, String valueStr) {
+			throw new UnsupportedOperationException("unknown column type " + toString());
+		}
+
+		public void setRowField(Row row, int fieldIdx, Record record, String odpsColumnName) {
+			throw new UnsupportedOperationException("unknown column type " + toString());
+		}
+	},
+
+	ARRAY {
+		public TypeInformation<?> toFlinkType() {
+			throw new UnsupportedOperationException("unknown column type " + toString());
+		}
+
+		public void setRowField(Row row, int fieldIdx, String valueStr) {
+			throw new UnsupportedOperationException("unknown column type " + toString());
+		}
+
+		public void setRowField(Row row, int fieldIdx, Record record, String odpsColumnName) {
+			throw new UnsupportedOperationException("unknown column type " + toString());
+		}
+	};
+
+	/**
+	 * mapping from odps type to flink type information
+	 *
+	 * @return related flink type information
+	 */
+	public abstract TypeInformation<?> toFlinkType();
+
+	/**
+	 * translate the value str to the correct type value, set the translated value to specified
+	 * location of row
+	 *
+	 * @param row      row to hold translated value
+	 * @param fieldIdx index of field in row to hold translated value
+	 * @param valueStr the string value to translate
+	 */
+	public abstract void setRowField(Row row, int fieldIdx, String valueStr);
+
+	/**
+	 * get the odps column value from Record, set the value to specified location of row
+	 *
+	 * @param row
+	 * @param fieldIdx
+	 * @param record
+	 * @param odpsColumnName
+	 */
+	public abstract void setRowField(Row row, int fieldIdx, Record record, String odpsColumnName);
+}

--- a/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/util/ElementSplitUtil.java
+++ b/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/util/ElementSplitUtil.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.blink.odps.util;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * A utility to divide total counts into numSplits parts as equal as possible.
+ */
+public class ElementSplitUtil {
+
+	/**
+	 * sum the input counts, and divide total count into numSplits parts as equal as possible
+	 *
+	 * @param elementCounts input counts
+	 * @param numSplits     specify how many parts to divide into
+	 * @return two dimension array which length is numSplits, and every element in these array
+	 * contain segments
+	 */
+	public static ElementSegment[][] doSplit(long[] elementCounts, int numSplits) {
+		checkArgument(elementCounts != null && allPositive(elementCounts),
+				"element counts is null or contain illegal element! ");
+		checkArgument(numSplits > 0, "num splits is less than 1! ");
+		int numElements = elementCounts.length;
+		if(numElements == 0) {
+			return new ElementSegment[numSplits][0];
+		}
+		long totalCount = 0;
+		// generate <element absolute start position , element absolute end position> arrays
+		long[][] elementBoundaries = new long[numElements][2];
+		for (int idx = 0; idx < numElements; idx++) {
+			long[] elementBoundary = new long[2];
+			elementBoundary[0] = totalCount;
+			totalCount += elementCounts[idx];
+			elementBoundary[1] = totalCount - 1;
+			elementBoundaries[idx] = elementBoundary;
+		}
+		long averageSplitCount = totalCount / numSplits;
+		ElementSegment[][] splitResult = new ElementSegment[numSplits][];
+		for (int splitIdx = 0; splitIdx < numSplits; splitIdx++) {
+			long splitStartAbsolutePos = splitIdx * averageSplitCount;
+			long splitCount = splitIdx < numSplits - 1 ? averageSplitCount :
+					averageSplitCount + totalCount % numSplits;
+			long splitEndAbsolutePos = splitStartAbsolutePos + splitCount - 1;
+
+			int startElementId = floorElementLocation(elementBoundaries, splitStartAbsolutePos);
+			int endElementId = floorElementLocation(elementBoundaries, splitEndAbsolutePos);
+			int elementNums = endElementId + 1 - startElementId;
+			ElementSegment[] elementsInOneSplit = new ElementSegment[elementNums];
+			for (int partId = startElementId; partId <= endElementId; partId++) {
+				long startAbsolutePosition = splitStartAbsolutePos < elementBoundaries[partId][0] ?
+						elementBoundaries[partId][0] : splitStartAbsolutePos;
+				long endAbsolutePosition = splitEndAbsolutePos < elementBoundaries[partId][1] ?
+						splitEndAbsolutePos : elementBoundaries[partId][1];
+				long startRelativePosition = startAbsolutePosition - elementBoundaries[partId][0];
+				long partCount = endAbsolutePosition + 1 - startAbsolutePosition;
+				elementsInOneSplit[partId - startElementId] =
+						new ElementSegment(partId, startRelativePosition, partCount);
+			}
+			splitResult[splitIdx] = elementsInOneSplit;
+		}
+		return splitResult;
+	}
+
+	private static boolean allPositive(long[] elementCounts) {
+		for (long count : elementCounts) {
+			if (count < 0) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Gets the position is corresponding to the specified value; if no such value exists, returns
+	 * the position for the greatest value less than the specified value
+	 *
+	 * @param elements
+	 * @param toSearch
+	 * @return
+	 */
+	private static int floorElementLocation(long[][] elements, long toSearch) {
+		int len = elements.length;
+		int left = 0;
+		int right = len - 1;
+		int mid;
+		while (left <= right) {
+			mid = (left + right) >>> 1;
+			if (elements[mid][0] < toSearch) {
+				left = left + 1;
+			} else if (elements[mid][0] == toSearch) {
+				return mid;
+			} else {
+				right = right - 1;
+			}
+		}
+		return right;
+	}
+
+	private ElementSplitUtil() {
+
+	}
+
+	public static class ElementSegment {
+		private final int elementId;
+		private final long start;
+		private final long count;
+
+		public ElementSegment(int elementId, long start, long count) {
+			this.elementId = elementId;
+			this.start = start;
+			this.count = count;
+		}
+
+		public int getElementId() {
+			return elementId;
+		}
+
+		public long getStart() {
+			return start;
+		}
+
+		public long getCount() {
+			return count;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+
+			ElementSegment that = (ElementSegment) o;
+
+			if (elementId != that.elementId) {
+				return false;
+			}
+			if (start != that.start) {
+				return false;
+			}
+			return count == that.count;
+
+		}
+
+		@Override
+		public int hashCode() {
+			int result = elementId;
+			result = 31 * result + (int) (start ^ (start >>> 32));
+			result = 31 * result + (int) (count ^ (count >>> 32));
+			return result;
+		}
+
+		@Override
+		public String toString() {
+			return "ElementSegment{" +
+					"elementId=" + elementId +
+					", start=" + start +
+					", count=" + count +
+					'}';
+		}
+	}
+}

--- a/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/util/ODPSUtil.java
+++ b/blink/blink-connectors/blink-connector-odps/src/main/java/com/alibaba/blink/odps/util/ODPSUtil.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.blink.odps.util;
+
+import com.alibaba.blink.odps.conf.ODPSConf;
+import com.alibaba.blink.odps.schema.ODPSTableSchema;
+import com.aliyun.odps.Odps;
+import com.aliyun.odps.Partition;
+import com.aliyun.odps.PartitionSpec;
+import com.aliyun.odps.Table;
+import com.aliyun.odps.TableSchema;
+import com.aliyun.odps.account.Account;
+import com.aliyun.odps.account.AliyunAccount;
+import com.google.common.base.Function;
+import com.google.common.collect.FluentIterable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * utility for ODPS
+ */
+public class ODPSUtil {
+	private static final Logger LOGGER = LoggerFactory.getLogger(ODPSUtil.class);
+
+	/**
+	 * create odps instance using odps configuration
+	 *
+	 * @param odpsConf odps configuration
+	 * @return odps instance
+	 */
+	public static Odps initOdps(ODPSConf odpsConf) {
+		return initOdps(
+				odpsConf.getAccessId(),
+				odpsConf.getAccessKey(),
+				odpsConf.getEndpoint(),
+				odpsConf.getProject());
+	}
+
+	/**
+	 * create odps instance
+	 *
+	 * @param accessId       access id
+	 * @param accessKey      access key
+	 * @param endpoint       endopint
+	 * @param defaultProject default project
+	 * @return new created odps instance
+	 */
+	public static Odps initOdps(String accessId, String accessKey, String endpoint,
+			String defaultProject) {
+		Account account = new AliyunAccount(accessId, accessKey);
+		Odps odps = new Odps(account);
+		odps.setEndpoint(endpoint);
+		if (defaultProject != null) {
+			odps.setDefaultProject(defaultProject);
+		}
+		return odps;
+	}
+
+	/**
+	 * fetch table schema of a specific odps table
+	 *
+	 * @param odpsConf
+	 * @param table
+	 * @return
+	 */
+	public static ODPSTableSchema getODPSTableSchema(ODPSConf odpsConf, String table) {
+		Odps odps = initOdps(odpsConf);
+		Table odpsTable = odps.tables().get(odpsConf.getProject(), table);
+		TableSchema schema = odpsTable.getSchema();
+		boolean isView = odpsTable.isVirtualView();
+		return new ODPSTableSchema(schema.getColumns(), schema.getPartitionColumns(), isView);
+	}
+
+	/**
+	 * fetch size of an odps table
+	 *
+	 * @param odpsConf odps configuration
+	 * @param table    odps table name
+	 * @return total size of an odps table
+	 */
+	public static long getTableSize(ODPSConf odpsConf, String table) {
+		Odps odps = initOdps(odpsConf);
+		Table t = odps.tables().get(odpsConf.getProject(), table);
+		return t.getSize();
+	}
+
+	/**
+	 * fetch size of an odps table partition
+	 *
+	 * @param odpsConf  odps configuration
+	 * @param table     odps table name
+	 * @param partition a specify odps table partition, e.g pt='1',ds='2'
+	 * @return total size of an odps table partition
+	 */
+	public static long getPartitionSize(ODPSConf odpsConf, String table, String partition) {
+		Odps odps = initOdps(odpsConf);
+		Table t = odps.tables().get(odpsConf.getProject(), table);
+		return t.getPartition(new PartitionSpec(partition)).getSize();
+	}
+
+	/**
+	 * fetch last modify time of an odps table
+	 *
+	 * @param odpsConf odps configuration
+	 * @param table    odps table name
+	 * @return last modify time of an odps table
+	 */
+	public static long getTableLastModifyTime(ODPSConf odpsConf, String table) {
+		Odps odps = initOdps(odpsConf);
+		Table t = odps.tables().get(odpsConf.getProject(), table);
+		return t.getLastDataModifiedTime().getTime();
+	}
+
+	/**
+	 * fetch last modify time of an odps table partition
+	 *
+	 * @param odpsConf  odps configuration
+	 * @param table     odps table name
+	 * @param partition a specify odps table partition, e.g pt='1',ds='2'
+	 * @return last modify time of an odps table partition
+	 */
+	public static long getPartitionLastModifyTime(ODPSConf odpsConf, String table,
+			String partition)
+	{
+		Odps odps = initOdps(odpsConf);
+		Table t = odps.tables().get(odpsConf.getProject(), table);
+		return t.getPartition(new PartitionSpec(partition)).getLastDataModifiedTime().getTime();
+	}
+
+	/**
+	 * fetch all partitions of an odps table
+	 *
+	 * @param odpsConf odps configuration
+	 * @param table    odps table name
+	 * @return all partitions of an odps table
+	 */
+	public static String[] getAllPartitions(ODPSConf odpsConf, String table) {
+		Odps odps = initOdps(odpsConf);
+		Table t = odps.tables().get(odpsConf.getProject(), table);
+		List<Partition> partitions = t.getPartitions();
+		return FluentIterable.from(partitions).transform(new Function<Partition, String>() {
+
+			@Override
+			public String apply(Partition partition) {
+				return partition.getPartitionSpec().toString();
+			}
+
+		}).toArray(String.class);
+	}
+
+	/**
+	 * deprecate default constructor
+	 */
+	private ODPSUtil() {
+
+	}
+}
+

--- a/blink/blink-connectors/blink-connector-odps/src/main/resources/externalcatalogTable.properties
+++ b/blink/blink-connectors/blink-connector-odps/src/main/resources/externalcatalogTable.properties
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+scan.package=com.alibaba.blink.odps

--- a/blink/blink-connectors/blink-connector-odps/src/test/java/com/alibaba/blink/odps/util/ElementSplitUtilTest.java
+++ b/blink/blink-connectors/blink-connector-odps/src/test/java/com/alibaba/blink/odps/util/ElementSplitUtilTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.blink.odps.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ElementSplitUtilTest {
+
+	@Test
+	public void doSplit() throws Exception {
+
+		ElementSplitUtil.ElementSegment[][] actualSegments =
+				ElementSplitUtil.doSplit(new long[]{1L, 1L, 1L}, 4);
+
+		ElementSplitUtil.ElementSegment[][] expectSegments =
+				new ElementSplitUtil.ElementSegment[4][];
+		expectSegments[0] = new ElementSplitUtil.ElementSegment[0];
+		expectSegments[1] = new ElementSplitUtil.ElementSegment[0];
+		expectSegments[2] = new ElementSplitUtil.ElementSegment[0];
+		expectSegments[3] = new ElementSplitUtil.ElementSegment[] {
+				new ElementSplitUtil.ElementSegment(0, 0L, 1L),
+				new ElementSplitUtil.ElementSegment(1, 0L, 1L),
+				new ElementSplitUtil.ElementSegment(2, 0L, 1L)
+		};
+
+		Assert.assertArrayEquals(expectSegments, actualSegments);
+
+		long[] inputCounts1 = new long[]{2L, 1L, 4L};
+
+		ElementSplitUtil.ElementSegment[][] actualSegments1 =
+				ElementSplitUtil.doSplit(inputCounts1, 1);
+
+		ElementSplitUtil.ElementSegment[][] expectSegments1 =
+				new ElementSplitUtil.ElementSegment[1][];
+		expectSegments1[0] = new ElementSplitUtil.ElementSegment[] {
+				new ElementSplitUtil.ElementSegment(0, 0L, 2L),
+				new ElementSplitUtil.ElementSegment(1, 0L, 1L),
+				new ElementSplitUtil.ElementSegment(2, 0L, 4L)
+		};
+
+		Assert.assertArrayEquals(expectSegments1, actualSegments1);
+
+		long[] inputCounts = new long[]{2L, 1L, 4L};
+
+		ElementSplitUtil.ElementSegment[][] actualSegments2 =
+				ElementSplitUtil.doSplit(inputCounts, 2);
+
+
+		ElementSplitUtil.ElementSegment[][] expectSegments2 =
+				new ElementSplitUtil.ElementSegment[2][];
+		expectSegments2[0] = new ElementSplitUtil.ElementSegment[] {
+				new ElementSplitUtil.ElementSegment(0, 0L, 2L),
+				new ElementSplitUtil.ElementSegment(1, 0L, 1L),
+		};
+		expectSegments2[1] = new ElementSplitUtil.ElementSegment[] {
+				new ElementSplitUtil.ElementSegment(2, 0L, 4L)
+		};
+
+		Assert.assertArrayEquals(expectSegments2, actualSegments2);
+
+		ElementSplitUtil.ElementSegment[][] actualSegments3 =
+				ElementSplitUtil.doSplit(inputCounts, 3);
+
+		ElementSplitUtil.ElementSegment[][] expectSegments3 =
+				new ElementSplitUtil.ElementSegment[3][];
+		expectSegments3[0] = new ElementSplitUtil.ElementSegment[] {
+				new ElementSplitUtil.ElementSegment(0, 0L, 2L)
+		};
+		expectSegments3[1] = new ElementSplitUtil.ElementSegment[] {
+				new ElementSplitUtil.ElementSegment(1, 0L, 1L),
+				new ElementSplitUtil.ElementSegment(2, 0L, 1L),
+		};
+		expectSegments3[2] = new ElementSplitUtil.ElementSegment[] {
+				new ElementSplitUtil.ElementSegment(2, 1L, 3L)
+		};
+		Assert.assertArrayEquals(expectSegments3, actualSegments3);
+	}
+}

--- a/blink/blink-connectors/pom.xml
+++ b/blink/blink-connectors/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>blink</artifactId>
+        <groupId>com.alibaba.blink</groupId>
+        <version>1.3-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.alibaba.blink</groupId>
+    <artifactId>blink-connectors</artifactId>
+    <packaging>pom</packaging>
+    <version>1.3-SNAPSHOT</version>
+    <modules>
+        <module>blink-connector-odps</module>
+    </modules>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table_2.10</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>create-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/blink/pom.xml
+++ b/blink/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>flink-parent</artifactId>
+        <groupId>org.apache.flink</groupId>
+        <version>1.3-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.alibaba.blink</groupId>
+    <artifactId>blink</artifactId>
+    <packaging>pom</packaging>
+    <version>1.3-SNAPSHOT</version>
+    <modules>
+        <module>blink-connectors</module>
+    </modules>
+
+
+</project>

--- a/flink-libraries/flink-table/pom.xml
+++ b/flink-libraries/flink-table/pom.xml
@@ -92,7 +92,12 @@ under the License.
 			</exclusions>
 		</dependency>
 
-
+		<dependency>
+			<groupId>org.reflections</groupId>
+			<artifactId>reflections</artifactId>
+			<version>0.9.10</version>
+			<scope>compile</scope>
+		</dependency>
 		<!-- test dependencies -->
 
 		<dependency>

--- a/flink-libraries/flink-table/src/main/java/org/apache/flink/table/annotation/ExternalCatalogCompatible.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/flink/table/annotation/ExternalCatalogCompatible.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.annotation;
+
+import org.apache.flink.annotation.Public;
+import org.apache.flink.table.catalog.TableSourceConverter;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A tableSource with this annotation represents it is compatible with external catalog, that is,
+ * an instance of this tableSource can be converted to or converted from external catalog table
+ * instance.
+ * The annotation contains the following information:
+ * <ul>
+ * <li> external catalog table type name for this kind of tableSource </li>
+ * <li> external catalog table <-> tableSource converter class </li>
+ * </ul>
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Public
+public @interface ExternalCatalogCompatible {
+
+	/**
+	 * Specifies the external catalog table type of this kind of tableSource.
+	 * e.g tableType of CsvTableSource can be csv, the tableType of HBaseTableSource can be hbase.
+	 *
+	 * @return the external catalog table type of this kind of tableSource.
+	 */
+	String tableType();
+
+	/**
+	 * Specifies the converter class for this kind of tableSource
+	 * which is used to convert {@link org.apache.flink.table.catalog.ExternalCatalogTable} to
+	 * or from {@link org.apache.flink.table.sources.TableSource}
+	 *
+	 * @return the converter class for this kind of tableSource.
+	 */
+	Class<? extends TableSourceConverter<?>> converter();
+
+}

--- a/flink-libraries/flink-table/src/main/resources/externalcatalogTable.properties
+++ b/flink-libraries/flink-table/src/main/resources/externalcatalogTable.properties
@@ -1,0 +1,19 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+scan.package=org.apache.flink.table.sources

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/exceptions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/exceptions.scala
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.api
 
+import org.apache.flink.table.catalog.ExternalCatalogTypes.PartitionSpec
+
 /**
   * Exception for all errors occurring during expression parsing.
   */
@@ -71,6 +73,48 @@ object ValidationException {
   * Exception for unwanted method calling on unresolved expression.
   */
 case class UnresolvedException(msg: String) extends RuntimeException(msg)
+
+/**
+  * Exception for operation on a nonexistent partition
+  *
+  * @param db            database name
+  * @param table         table name
+  * @param partitionSpec partition spec
+  * @param cause
+  */
+case class PartitionNotExistException(
+    db: String,
+    table: String,
+    partitionSpec: PartitionSpec,
+    cause: Throwable)
+    extends RuntimeException(
+      s"partition [${partitionSpec.mkString(", ")}] does not exist in table $db.$table!", cause) {
+
+  def this(db: String, table: String, partitionSpec: PartitionSpec) =
+    this(db, table, partitionSpec, null)
+
+}
+
+/**
+  * Exception for adding an already existed partition
+  *
+  * @param db            database name
+  * @param table         table name
+  * @param partitionSpec partition spec
+  * @param cause
+  */
+case class PartitionAlreadyExistException(
+    db: String,
+    table: String,
+    partitionSpec: PartitionSpec,
+    cause: Throwable)
+    extends RuntimeException(
+      s"partition [${partitionSpec.mkString(", ")}] already exists in table $db.$table!", cause) {
+
+  def this(db: String, table: String, partitionSpec: PartitionSpec) =
+    this(db, table, partitionSpec, null)
+
+}
 
 /**
   * Exception for operation on a nonexistent table

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/exceptions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/exceptions.scala
@@ -134,6 +134,35 @@ case class DatabaseAlreadyExistException(
   def this(db: String) = this(db, null)
 }
 
+
+/**
+  * Exception for operation on a nonexistent external catalog
+  *
+  * @param catalogName external catalog name
+  * @param cause
+  */
+case class ExternalCatalogNotExistException(
+    catalogName: String,
+    cause: Throwable)
+    extends RuntimeException(s"external catalog $catalogName does not exist!", cause) {
+
+  def this(catalogName: String) = this(catalogName, null)
+}
+
+/**
+  * Exception for adding an already existed external catalog
+  *
+  * @param catalogName external catalog name
+  * @param cause
+  */
+case class ExternalCatalogAlreadyExistException(
+    catalogName: String,
+    cause: Throwable)
+    extends RuntimeException(s"external catalog $catalogName already exists!", cause) {
+
+  def this(catalogName: String) = this(catalogName, null)
+}
+
 /**
   * Exception for operation on a nonexistent external catalog table type
   *

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/exceptions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/exceptions.scala
@@ -71,3 +71,93 @@ object ValidationException {
   * Exception for unwanted method calling on unresolved expression.
   */
 case class UnresolvedException(msg: String) extends RuntimeException(msg)
+
+/**
+  * Exception for operation on a nonexistent table
+  *
+  * @param db    database name
+  * @param table table name
+  * @param cause
+  */
+case class TableNotExistException(
+    db: String,
+    table: String,
+    cause: Throwable)
+    extends RuntimeException(s"table $db.$table does not exist!", cause) {
+
+  def this(db: String, table: String) = this(db, table, null)
+
+}
+
+/**
+  * Exception for adding an already existed table
+  *
+  * @param db    database name
+  * @param table table name
+  * @param cause
+  */
+case class TableAlreadyExistException(
+    db: String,
+    table: String,
+    cause: Throwable)
+    extends RuntimeException(s"table $db.$table already exists!", cause) {
+
+  def this(db: String, table: String) = this(db, table, null)
+
+}
+
+/**
+  * Exception for operation on a nonexistent database
+  *
+  * @param db database name
+  * @param cause
+  */
+case class DatabaseNotExistException(
+    db: String,
+    cause: Throwable)
+    extends RuntimeException(s"database $db does not exist!", cause) {
+
+  def this(db: String) = this(db, null)
+}
+
+/**
+  * Exception for adding an already existed database
+  *
+  * @param db database name
+  * @param cause
+  */
+case class DatabaseAlreadyExistException(
+    db: String,
+    cause: Throwable)
+    extends RuntimeException(s"database $db already exists!", cause) {
+
+  def this(db: String) = this(db, null)
+}
+
+/**
+  * Exception for operation on a nonexistent external catalog table type
+  *
+  * @param tableType external catalog table type
+  * @param cause
+  */
+case class ExternalCatalogTableTypeNotExistException(
+    tableType: String,
+    cause: Throwable)
+    extends RuntimeException(s"external catalog table type $tableType does not exist!", cause) {
+
+  def this(tableType: String) = this(tableType, null)
+}
+
+/**
+  * Exception for adding an already existed external catalog
+  *
+  * @param tableType external catalog table type
+  * @param cause
+  */
+case class ExternalCatalogTableTypeAlreadyExistException(
+    tableType: String,
+    cause: Throwable)
+    extends RuntimeException(s"external catalog table type $tableType already exists!", cause) {
+
+  def this(tableType: String) = this(tableType, null)
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/CatalogTableHelper.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/CatalogTableHelper.scala
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+import java.io.IOException
+import java.lang.reflect.Modifier
+import java.net.URL
+import java.util.Properties
+
+import org.apache.flink.table.annotation.ExternalCatalogCompatible
+import org.apache.flink.table.api.{ExternalCatalogTableTypeAlreadyExistException, ExternalCatalogTableTypeNotExistException}
+import org.apache.flink.table.plan.schema.TableSourceTable
+import org.apache.flink.table.plan.stats.FlinkStatistic
+import org.apache.flink.table.sources.TableSource
+import org.apache.flink.util.InstantiationUtil
+import org.reflections.Reflections
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.HashMap
+
+/**
+  * The utility class is used to convert ExternalCatalogTable to TableSourceTable.
+  */
+object CatalogTableHelper {
+
+  // config file to specifier the scan package to search tableSources
+  // which is compatible with external catalog.
+  private val tableSourceConfigFileName = "externalcatalogTable.properties"
+
+  private val LOG: Logger = LoggerFactory.getLogger(this.getClass)
+
+  // registered tableSources which are compatible with external catalog.
+  // Key is table type name, Value is converter class.
+  private val tableSourceTypeToConvertersClazz = {
+    val registeredConverters =
+      new HashMap[String, Class[_ <: TableSourceConverter[_]]]
+    // scan all config file to find all tableSources which are compatible with external catalog.
+    val resourceUrls = getClass.getClassLoader.getResources(tableSourceConfigFileName)
+    while (resourceUrls.hasMoreElements) {
+      val url = resourceUrls.nextElement()
+      parseScanPackageFromConfigFile(url) match {
+        case Some(scanPackage) =>
+          val clazzWithAnnotations = new Reflections(scanPackage)
+              .getTypesAnnotatedWith(classOf[ExternalCatalogCompatible])
+          clazzWithAnnotations.asScala.foreach(clazz =>
+            if (classOf[TableSource[_]].isAssignableFrom(clazz)) {
+              if (Modifier.isAbstract(clazz.getModifiers()) ||
+                  Modifier.isInterface(clazz.getModifiers)) {
+                LOG.warn(
+                  s"class :[${clazz.getName}] is also with ExternalCatalogCompatible annotation, " +
+                      s"but it's an abstract clazz or an interface.")
+              } else {
+                val externalCatalogCompatible: ExternalCatalogCompatible =
+                  clazz.getAnnotation(classOf[ExternalCatalogCompatible])
+                val tableSourceName = externalCatalogCompatible.tableType()
+                if (registeredConverters.contains(tableSourceName)) {
+                  LOG.error(s"The table type [$tableSourceName] is already registered.")
+                  throw new ExternalCatalogTableTypeAlreadyExistException(tableSourceName)
+                }
+                registeredConverters.put(tableSourceName, externalCatalogCompatible.converter())
+              }
+            } else {
+              LOG.warn(
+                s"class :[${clazz.getName}] is also with ExternalCatalogCompatible annotation, " +
+                    s"but it's not sub-class of tableSource.")
+            }
+          )
+        case None =>
+      }
+    }
+    registeredConverters
+  }
+
+  /**
+    * Converts an [[ExternalCatalogTable]] instance to a [[TableSourceTable]] instance
+    *
+    * @param externalCatalogTable the [[ExternalCatalogTable]] instance which to convert
+    * @return converted [[TableSourceTable]] instance from the input catalog table
+    */
+  def fromExternalCatalogTable(externalCatalogTable: ExternalCatalogTable): TableSourceTable[_] = {
+    val tableType = externalCatalogTable.tableType
+    tableSourceTypeToConvertersClazz.get(tableType) match {
+      case Some(converterClazz) =>
+        val converter = InstantiationUtil.instantiate(converterClazz)
+        val convertedTableSource: TableSource[_] =
+          converter.fromExternalCatalogTable(externalCatalogTable) match {
+            case ts: TableSource[_] => ts
+            case _ => throw new RuntimeException(
+              s"the converted result from converter ${converterClazz.getName} " +
+                  s"is not tableSource instance")
+          }
+
+        val flinkStatistic = externalCatalogTable.stats match {
+          case Some(stats) => FlinkStatistic.of(stats)
+          case None => FlinkStatistic.UNKNOWN
+        }
+        new TableSourceTable(convertedTableSource, flinkStatistic)
+      case None =>
+        LOG.error(s"the table type [$tableType] does not exist.")
+        throw new ExternalCatalogTableTypeNotExistException(tableType)
+    }
+  }
+
+  private def parseScanPackageFromConfigFile(url: URL): Option[String] = {
+    val properties = new Properties()
+    try {
+      properties.load(url.openStream())
+      val scanPackage = properties.getProperty("scan.package")
+      if (scanPackage == null || scanPackage.isEmpty) {
+        LOG.warn(s"config file $url does not contain scan package!")
+        None
+      } else {
+        Some(scanPackage)
+      }
+    } catch {
+      case e: IOException =>
+        LOG.warn(s"fail to open config file [$url]", e)
+        None
+    }
+  }
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalog.scala
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+/**
+  * This class is responsible for interact with external catalog.
+  * Its main responsibilities including:
+  * <ul>
+  * <li> create/drop/alter database or tables for DDL operations
+  * <li> provide tables for calcite catalog, it looks up databases or tables in the external catalog
+  * </ul>
+  */
+trait ExternalCatalog {
+
+  /**
+    * Adds table into external Catalog
+    *
+    * @param table          description of table which to create
+    * @param ignoreIfExists whether to ignore operation if table already exists
+    */
+  def createTable(table: ExternalCatalogTable, ignoreIfExists: Boolean): Unit
+
+  /**
+    * Deletes table from external Catalog
+    *
+    * @param dbName            database name
+    * @param tableName         table name
+    * @param ignoreIfNotExists whether to ignore operation if table not exist yet
+    */
+  def dropTable(dbName: String, tableName: String, ignoreIfNotExists: Boolean): Unit
+
+  /**
+    * Alters existed table into external Catalog
+    *
+    * @param table description of table which to alter
+    */
+  def alterTable(table: ExternalCatalogTable): Unit
+
+  /**
+    * Gets table from external Catalog
+    *
+    * @param dbName    database name
+    * @param tableName table name
+    * @return table
+    */
+  def getTable(dbName: String, tableName: String): ExternalCatalogTable
+
+  /**
+    * Gets the table name lists from current external Catalog
+    *
+    * @param dbName database name
+    * @return lists of table name
+    */
+  def listTables(dbName: String): Seq[String]
+
+  /**
+    * Adds database into external Catalog
+    *
+    * @param db             database name
+    * @param ignoreIfExists whether to ignore operation if database already exists
+    */
+  def createDatabase(db: ExternalCatalogDatabase, ignoreIfExists: Boolean): Unit
+
+  /**
+    * Deletes database from external Catalog
+    *
+    * @param dbName            database name
+    * @param ignoreIfNotExists whether to ignore operation if table not exist yet
+    */
+  def dropDatabase(dbName: String, ignoreIfNotExists: Boolean): Unit
+
+  /**
+    * Alters existed database into external Catalog
+    */
+  def alterDatabase(db: ExternalCatalogDatabase): Unit
+
+  /**
+    * Gets database from external Catalog
+    *
+    * @param dbName database name
+    * @return database
+    */
+  def getDatabase(dbName: String): ExternalCatalogDatabase
+
+  /**
+    * Gets the database name lists from current external Catalog
+    *
+    * @return
+    */
+  def listDatabases(): Seq[String]
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalog.scala
@@ -18,15 +18,76 @@
 
 package org.apache.flink.table.catalog
 
+import org.apache.flink.table.catalog.ExternalCatalogTypes.PartitionSpec
+
 /**
   * This class is responsible for interact with external catalog.
   * Its main responsibilities including:
   * <ul>
-  * <li> create/drop/alter database or tables for DDL operations
+  * <li> create/drop/alter database, tables, partitions for DDL operations
   * <li> provide tables for calcite catalog, it looks up databases or tables in the external catalog
   * </ul>
   */
 trait ExternalCatalog {
+
+  /**
+    * Adds partitions into an external Catalog table
+    *
+    * @param dbName         database name
+    * @param tableName      table name
+    * @param part           partition description of partition which to create
+    * @param ignoreIfExists whether to ignore operation if table already exists
+    */
+  def createPartition(
+      dbName: String,
+      tableName: String,
+      part: ExternalCatalogTablePartition,
+      ignoreIfExists: Boolean): Unit
+
+  /**
+    * Deletes partition of an external Catalog table
+    *
+    * @param dbName            database name
+    * @param tableName         table name
+    * @param partSpec          partition specification
+    * @param ignoreIfNotExists whether to ignore operation if table not exist yet
+    */
+  def dropPartition(
+      dbName: String,
+      tableName: String,
+      partSpec: PartitionSpec,
+      ignoreIfNotExists: Boolean): Unit
+
+  /**
+    * Alters an existed external Catalog table partition
+    *
+    * @param dbName    database name
+    * @param tableName table name
+    * @param part      description of partition which to alter
+    */
+  def alterPartition(dbName: String, tableName: String, part: ExternalCatalogTablePartition): Unit
+
+  /**
+    * Gets the partition from external Catalog
+    *
+    * @param dbName    database name
+    * @param tableName table name
+    * @param partSpec  partition specification
+    * @return
+    */
+  def getPartition(
+      dbName: String,
+      tableName: String,
+      partSpec: PartitionSpec): ExternalCatalogTablePartition
+
+  /**
+    * Gets the partition specification list of a table from external catalog
+    *
+    * @param dbName    database name
+    * @param tableName table name
+    * @return
+    */
+  def listPartitionSpec(dbName: String, tableName: String): Seq[PartitionSpec]
 
   /**
     * Adds table into external Catalog

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogDatabase.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogDatabase.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+/**
+  * Database definition of the external catalog.
+  *
+  * @param dbName     database name
+  * @param properties database properties
+  */
+case class ExternalCatalogDatabase(
+    dbName: String,
+    properties: Map[String, String] = Map.empty)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogSchema.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogSchema.scala
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+import java.util
+
+import org.apache.calcite.linq4j.tree.Expression
+import org.apache.calcite.schema._
+import org.apache.flink.table.api.{DatabaseNotExistException, TableNotExistException}
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.collection.JavaConverters._
+
+/**
+  * This class is responsible for connect external catalog to calcite catalog.
+  * In this way, it is possible to look-up and access tables in SQL queries
+  * without registering tables in advance.
+  * The databases in the external catalog registers as calcite sub-Schemas of current schema.
+  * The tables in a given database registers as calcite tables
+  * of the [[ExternalCatalogDatabaseSchema]].
+  *
+  * @param catalogIdentifier external catalog name
+  * @param catalog           external catalog
+  */
+class ExternalCatalogSchema(
+    catalogIdentifier: String,
+    catalog: ExternalCatalog) extends Schema {
+
+  private val LOG: Logger = LoggerFactory.getLogger(this.getClass)
+
+  /**
+    * Looks up database by the given sub-schema name in the external catalog,
+    * returns it Wrapped in a [[ExternalCatalogDatabaseSchema]] with the given database name.
+    *
+    * @param name Sub-schema name
+    * @return Sub-schema with a given name, or null
+    */
+  override def getSubSchema(name: String): Schema = {
+    try {
+      val db = catalog.getDatabase(name)
+      if (db != null) {
+        new ExternalCatalogDatabaseSchema(db.dbName, catalog)
+      } else {
+        null
+      }
+    } catch {
+      case e: DatabaseNotExistException =>
+        LOG.warn(s"database $name does not exist in externalCatalog $catalogIdentifier")
+        null
+    }
+  }
+
+  /**
+    * Lists the databases of the external catalog,
+    * returns the lists as the names of this schema's sub-schemas.
+    *
+    * @return names of this schema's child schemas
+    */
+  override def getSubSchemaNames: util.Set[String] = catalog.listDatabases().toSet.asJava
+
+  override def getTable(name: String): Table = null
+
+  override def isMutable: Boolean = true
+
+  override def getFunctions(name: String): util.Collection[Function] =
+    util.Collections.emptyList[Function]
+
+  override def getExpression(parentSchema: SchemaPlus, name: String): Expression =
+    Schemas.subSchemaExpression(parentSchema, name, getClass)
+
+  override def getFunctionNames: util.Set[String] = util.Collections.emptySet[String]
+
+  override def getTableNames: util.Set[String] = util.Collections.emptySet[String]
+
+  override def contentsHaveChangedSince(lastCheck: Long, now: Long): Boolean = false
+
+  /**
+    * Registers sub-Schemas to current schema plus
+    *
+    * @param plusOfThis
+    */
+  def registerSubSchemas(plusOfThis: SchemaPlus) {
+    catalog.listDatabases().foreach(
+      dbName => plusOfThis.add(dbName, getSubSchema(dbName))
+    )
+  }
+
+  private class ExternalCatalogDatabaseSchema(
+      schemaName: String,
+      flinkExternalCatalog: ExternalCatalog) extends Schema {
+
+    override def getTable(name: String): Table = {
+      try {
+        val externalCatalogTable = flinkExternalCatalog.getTable(schemaName, name)
+        if (externalCatalogTable != null) {
+          CatalogTableHelper.fromExternalCatalogTable(externalCatalogTable)
+        } else {
+          null
+        }
+      } catch {
+        case TableNotExistException(db, table, cause) => {
+          LOG.warn(s"table $db.$table does not exist in externalCatalog $catalogIdentifier")
+          null
+        }
+      }
+    }
+
+    override def getTableNames: util.Set[String] =
+      flinkExternalCatalog.listTables(schemaName).toSet.asJava
+
+    override def getSubSchema(name: String): Schema = null
+
+    override def getSubSchemaNames: util.Set[String] = util.Collections.emptySet[String]
+
+    override def isMutable: Boolean = true
+
+    override def getFunctions(name: String): util.Collection[Function] =
+      util.Collections.emptyList[Function]
+
+    override def getExpression(parentSchema: SchemaPlus, name: String): Expression =
+      Schemas.subSchemaExpression(parentSchema, name, getClass)
+
+    override def getFunctionNames: util.Set[String] = util.Collections.emptySet[String]
+
+    override def contentsHaveChangedSince(lastCheck: Long, now: Long): Boolean = false
+
+  }
+
+}
+
+object ExternalCatalogSchema {
+
+  /**
+    * Creates a FlinkExternalCatalogSchema.
+    *
+    * @param parentSchema              Parent schema
+    * @param externalCatalogIdentifier External catalog identifier
+    * @param externalCatalog           External catalog object
+    * @return Created schema
+    */
+  def create(
+      parentSchema: SchemaPlus,
+      externalCatalogIdentifier: String,
+      externalCatalog: ExternalCatalog): ExternalCatalogSchema = {
+    val newSchema = new ExternalCatalogSchema(externalCatalogIdentifier, externalCatalog)
+    val schemaPlusOfNewSchema = parentSchema.add(externalCatalogIdentifier, newSchema)
+    newSchema.registerSubSchemas(schemaPlusOfNewSchema)
+    newSchema
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
@@ -30,6 +30,7 @@ import org.apache.flink.table.plan.stats.TableStats
   * @param properties           properties of external catalog table
   * @param stats                statistics of external catalog table
   * @param comment              comment of external catalog table
+  * @param partitionColumnNames partition columns name list
   * @param createTime           create time of external catalog table
   * @param lastAccessTime       last access time of of external catalog table
   */
@@ -40,6 +41,8 @@ case class ExternalCatalogTable(
     properties: Map[String, String] = Map.empty,
     stats: Option[TableStats] = None,
     comment: Option[String] = None,
+    partitionColumnNames: Seq[String] = Seq.empty,
+    isPartitioned: Boolean = false,
     createTime: Long = System.currentTimeMillis,
     lastAccessTime: Long = -1)
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTable.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.table.plan.stats.TableStats
+
+/**
+  * Table definition of the external catalog.
+  *
+  * @param identifier           identifier of external catalog table, including dbName and tableName
+  * @param tableType            type of external catalog table, e.g csv, hbase, kafka
+  * @param schema               schema of table data, including column names and column types
+  * @param properties           properties of external catalog table
+  * @param stats                statistics of external catalog table
+  * @param comment              comment of external catalog table
+  * @param createTime           create time of external catalog table
+  * @param lastAccessTime       last access time of of external catalog table
+  */
+case class ExternalCatalogTable(
+    identifier: TableIdentifier,
+    tableType: String,
+    schema: DataSchema,
+    properties: Map[String, String] = Map.empty,
+    stats: Option[TableStats] = None,
+    comment: Option[String] = None,
+    createTime: Long = System.currentTimeMillis,
+    lastAccessTime: Long = -1)
+
+/**
+  * Identifier of external catalog table
+  *
+  * @param database database name
+  * @param table    table name
+  */
+case class TableIdentifier(
+    database: String,
+    table: String) {
+
+  override def toString: String = s"$database.$table"
+
+}
+
+/**
+  * Schema of External catalog table's columns
+  *
+  * @param columnTypes types of each column
+  * @param columnNames names of each column
+  */
+case class DataSchema(
+    columnTypes: Array[TypeInformation[_]],
+    columnNames: Array[String]) {
+
+  override def toString: String =
+    s"column types: [${columnTypes.mkString(",")}], column names: [${columnNames.mkString(",")}]"
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTablePartition.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogTablePartition.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+import org.apache.flink.table.plan.stats.TablePartitionStats
+
+object ExternalCatalogTypes {
+
+  /**
+    * external table partition specification.
+    * Key is partition column name, value is partition column value.
+    */
+  type PartitionSpec = Map[String, String]
+}
+
+/**
+  * Partition definition of an external Catalog table
+  *
+  * @param partitionSpec partition specification
+  * @param properties    partition properties
+  * @param stats         partition statistics
+  */
+case class ExternalCatalogTablePartition(
+    partitionSpec: ExternalCatalogTypes.PartitionSpec,
+    properties: Map[String, String] = Map.empty,
+    stats: Option[TablePartitionStats] = None)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/InMemoryExternalCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/InMemoryExternalCatalog.scala
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+import org.apache.flink.table.api.{DatabaseAlreadyExistException, DatabaseNotExistException, TableAlreadyExistException, TableNotExistException}
+
+import scala.collection.mutable.HashMap
+
+/**
+  * This class is an in-memory implementation of [[ExternalCatalog]].
+  *
+  * It could be used for testing or developing instead of used in production environment.
+  */
+class InMemoryExternalCatalog extends ExternalCatalog {
+
+  private val databases = new HashMap[String, Database]
+
+  override def createTable(
+      table: ExternalCatalogTable,
+      ignoreIfExists: Boolean): Unit = synchronized {
+    val dbName = table.identifier.database
+    val tables = getTables(dbName)
+    val tableName = table.identifier.table
+    if (tables.contains(tableName)) {
+      if (!ignoreIfExists) {
+        throw new TableAlreadyExistException(dbName, tableName)
+      }
+    } else {
+      tables.put(tableName, table)
+    }
+  }
+
+  override def dropTable(
+      dbName: String,
+      tableName: String,
+      ignoreIfNotExists: Boolean): Unit = synchronized {
+    val tables = getTables(dbName)
+    if (tables.remove(tableName).isEmpty && !ignoreIfNotExists) {
+      throw new TableNotExistException(dbName, tableName)
+    }
+  }
+
+  override def alterTable(table: ExternalCatalogTable): Unit = synchronized {
+    val dbName = table.identifier.database
+    val tables = getTables(dbName)
+    val tableName = table.identifier.table
+    if (tables.contains(tableName)) {
+      tables.put(tableName, table)
+    } else {
+      throw new TableNotExistException(dbName, tableName)
+    }
+  }
+
+  override def listTables(dbName: String): Seq[String] = synchronized {
+    val tables = getTables(dbName)
+    tables.keys.toSeq
+  }
+
+  override def getTable(dbName: String, tableName: String): ExternalCatalogTable = synchronized {
+    val tables = getTables(dbName)
+    tables.get(tableName) match {
+      case Some(table) => table
+      case None => throw new TableNotExistException(dbName, tableName)
+    }
+  }
+
+  override def createDatabase(
+      db: ExternalCatalogDatabase,
+      ignoreIfExists: Boolean): Unit = synchronized {
+    val dbName = db.dbName
+    if (databases.contains(dbName)) {
+      if (!ignoreIfExists) {
+        throw new DatabaseAlreadyExistException(dbName)
+      }
+    } else {
+      databases.put(dbName, new Database(db))
+    }
+  }
+
+  override def alterDatabase(db: ExternalCatalogDatabase): Unit = synchronized {
+    val dbName = db.dbName
+    databases.get(dbName) match {
+      case Some(database) => database.db = db
+      case None => throw new DatabaseNotExistException(dbName)
+    }
+  }
+
+  override def dropDatabase(
+      dbName: String,
+      ignoreIfNotExists: Boolean): Unit = synchronized {
+    if (databases.remove(dbName).isEmpty && !ignoreIfNotExists) {
+      throw new DatabaseNotExistException(dbName)
+    }
+  }
+
+  override def listDatabases(): Seq[String] = synchronized {
+    databases.keys.toSeq
+  }
+
+  override def getDatabase(dbName: String): ExternalCatalogDatabase = synchronized {
+    databases.get(dbName) match {
+      case Some(database) => database.db
+      case None => null
+    }
+  }
+
+  private def getTables(db: String): HashMap[String, ExternalCatalogTable] =
+    databases.get(db) match {
+      case Some(database) => database.tables
+      case None => throw new DatabaseNotExistException(db)
+    }
+
+  private class Database(var db: ExternalCatalogDatabase) {
+    val tables = new HashMap[String, ExternalCatalogTable]
+  }
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/TableSourceConverter.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/TableSourceConverter.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+import org.apache.flink.table.sources.TableSource
+
+/** Defines a converter used to convert [[org.apache.flink.table.sources.TableSource]] to
+  * or from [[ExternalCatalogTable]].
+  *
+  * @tparam T The tableSource type which to do convert operation on.
+  */
+trait TableSourceConverter[T <: TableSource[_]] {
+
+  /**
+    * Converts the input external catalog table instance to a tableSource instance.
+    *
+    * @param externalCatalogTable input external catalog table instance to convert
+    * @return converted tableSource instance from input external catalog table.
+    */
+  def fromExternalCatalogTable(externalCatalogTable: ExternalCatalogTable): T
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/logical/operators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/logical/operators.scala
@@ -511,15 +511,15 @@ case class Join(
 }
 
 case class CatalogNode(
-    tableName: String,
-    rowType: RelDataType) extends LeafNode {
+    rowType: RelDataType,
+    tableName: String*) extends LeafNode {
 
   val output: Seq[Attribute] = rowType.getFieldList.asScala.map { field =>
     ResolvedFieldReference(field.getName, FlinkTypeFactory.toTypeInfo(field.getType))
   }
 
   override protected[logical] def construct(relBuilder: RelBuilder): RelBuilder = {
-    relBuilder.scan(tableName)
+    relBuilder.scan(tableName.toList.asJava)
   }
 
   override def validate(tableEnv: TableEnvironment): LogicalNode = this

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/stats/TablePartitionStats.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/stats/TablePartitionStats.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.stats
+
+import java.util.{HashMap, Map}
+
+/**
+  * Table statistics
+  *
+  * @param rowCount cardinality of table
+  * @param colStats statistics of table columns
+  */
+case class TablePartitionStats(rowCount: Long, colStats: Map[String, ColumnStats] = new HashMap())

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/CsvTableSource.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/CsvTableSource.scala
@@ -27,6 +27,7 @@ import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.core.fs.Path
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.table.annotation.ExternalCatalogCompatible
 import org.apache.flink.table.api.TableException
 
 import scala.collection.mutable
@@ -45,6 +46,8 @@ import scala.collection.mutable
   * @param ignoreComments An optional prefix to indicate comments, null by default.
   * @param lenient Flag to skip records with parse error instead to fail, false by default.
   */
+
+@ExternalCatalogCompatible(tableType = "csv", converter = classOf[CsvTableSourceConverter])
 class CsvTableSource(
     private val path: String,
     private val fieldNames: Array[String],

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/CsvTableSourceConverter.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/CsvTableSourceConverter.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sources
+
+import org.apache.flink.table.catalog.{ExternalCatalogTable, TableSourceConverter}
+
+/**
+  * The class defines a converter used to convert [[CsvTableSource]] to
+  * or from [[ExternalCatalogTable]].
+  */
+class CsvTableSourceConverter extends TableSourceConverter[CsvTableSource] {
+
+  override def fromExternalCatalogTable(
+      externalCatalogTable: ExternalCatalogTable): CsvTableSource = {
+
+    val csvTableSourceBuilder = new CsvTableSource.Builder
+    val params = externalCatalogTable.properties
+    params.get("path").foreach(csvTableSourceBuilder.path)
+    params.get("fieldDelim").foreach(csvTableSourceBuilder.fieldDelimiter)
+    params.get("rowDelim").foreach(csvTableSourceBuilder.lineDelimiter)
+    params.get("quoteCharacter").foreach(quoteStr =>
+      if (quoteStr.length != 1) {
+        throw new IllegalArgumentException("the value of param quoteCharacter is invalid")
+      } else {
+        csvTableSourceBuilder.quoteCharacter(quoteStr.charAt(0))
+      }
+    )
+    params.get("ignoreFirstLine").foreach(ignoreFirstLineStr =>
+        if(ignoreFirstLineStr.toBoolean) {
+          csvTableSourceBuilder.ignoreFirstLine()
+        }
+    )
+    params.get("ignoreComments").foreach(csvTableSourceBuilder.commentPrefix)
+    params.get("lenient").foreach(lenientStr =>
+        if(lenientStr.toBoolean) {
+          csvTableSourceBuilder.ignoreParseErrors
+        }
+    )
+    externalCatalogTable.schema.columnNames
+        .zip(externalCatalogTable.schema.columnTypes)
+        .foreach(field => csvTableSourceBuilder.field(field._1, field._2))
+
+    csvTableSourceBuilder.build()
+  }
+
+}

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/batch/ExternalCatalogITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/batch/ExternalCatalogITCase.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.java.batch;
+
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.java.BatchTableEnvironment;
+import org.apache.flink.table.api.scala.batch.utils.TableProgramsCollectionTestBase;
+import org.apache.flink.table.catalog.TableIdentifier;
+import org.apache.flink.table.utils.CommonTestData;
+import org.apache.flink.types.Row;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+@RunWith(Parameterized.class)
+public class ExternalCatalogITCase extends TableProgramsCollectionTestBase {
+
+	public ExternalCatalogITCase(TableConfigMode configMode) {
+		super(configMode);
+	}
+
+	@Test
+	public void testSQL() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+
+		tableEnv.registerExternalCatalog("test", CommonTestData.getMockedFlinkExternalCatalog());
+
+		String sqlQuery = "SELECT * FROM test.db1.tb1 " +
+				"UNION ALL " +
+				"(SELECT d, e, g FROM test.db2.tb2 WHERE d < 3)";
+
+		Table result = tableEnv.sql(sqlQuery);
+
+		DataSet<Row> resultSet = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = resultSet.collect();
+		String expected = "1,1,Hi\n" + "2,2,Hello\n" + "3,2,Hello world\n"
+				+ "1,1,Hallo\n" + "2,2,Hallo Welt\n" + "2,3,Hallo Welt wie\n";
+		compareResultAsText(results, expected);
+	}
+
+	@Test
+	public void testTableAPI() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+
+		tableEnv.registerExternalCatalog("test", CommonTestData.getMockedFlinkExternalCatalog());
+
+		Table table1 = tableEnv.scan("test", new TableIdentifier("db1", "tb1"));
+		Table table2 = tableEnv.scan("test", new TableIdentifier("db2", "tb2"));
+		Table result = table2.where("d < 3").select("d, e, g").union(table1);
+
+		DataSet<Row> resultSet = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = resultSet.collect();
+		String expected = "1,1,Hi\n" + "2,2,Hello\n" + "3,2,Hello world\n"
+				+ "1,1,Hallo\n" + "2,2,Hallo Welt\n" + "2,3,Hallo Welt wie\n";
+		compareResultAsText(results, expected);
+	}
+}

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/stream/ExternalCatalogITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/api/java/stream/ExternalCatalogITCase.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.java.stream;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
+import org.apache.flink.table.api.scala.stream.utils.StreamITCase;
+import org.apache.flink.table.catalog.TableIdentifier;
+import org.apache.flink.table.utils.CommonTestData;
+import org.apache.flink.types.Row;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ExternalCatalogITCase {
+
+	@Test
+	public void testSQL() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+		StreamITCase.clear();
+
+		tableEnv.registerExternalCatalog("test", CommonTestData.getMockedFlinkExternalCatalog());
+
+		String sqlQuery = "SELECT * FROM test.db1.tb1 " +
+				"UNION ALL " +
+				"(SELECT d, e, g FROM test.db2.tb2 WHERE d < 3)";
+		Table result = tableEnv.sql(sqlQuery);
+
+		DataStream<Row> resultSet = tableEnv.toDataStream(result, Row.class);
+		resultSet.addSink(new StreamITCase.StringSink());
+		env.execute();
+
+		List<String> expected = new ArrayList<>();
+		expected.add("1,1,Hi");
+		expected.add("2,2,Hello");
+		expected.add("3,2,Hello world");
+		expected.add("1,1,Hallo");
+		expected.add("2,2,Hallo Welt");
+		expected.add("2,3,Hallo Welt wie");
+
+		StreamITCase.compareWithList(expected);
+	}
+
+	@Test
+	public void testTableAPI() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env);
+		StreamITCase.clear();
+
+		tableEnv.registerExternalCatalog("test", CommonTestData.getMockedFlinkExternalCatalog());
+
+		Table table1 = tableEnv.scan("test", new TableIdentifier("db1", "tb1"));
+		Table table2 = tableEnv.scan("test", new TableIdentifier("db2", "tb2"));
+		Table result = table2.where("d < 3").select("d, e, g").unionAll(table1);
+
+		DataStream<Row> resultSet = tableEnv.toDataStream(result, Row.class);
+		resultSet.addSink(new StreamITCase.StringSink());
+		env.execute();
+
+		List<String> expected = new ArrayList<>();
+		expected.add("1,1,Hi");
+		expected.add("2,2,Hello");
+		expected.add("3,2,Hello world");
+		expected.add("1,1,Hallo");
+		expected.add("2,2,Hallo Welt");
+		expected.add("2,3,Hallo Welt wie");
+
+		StreamITCase.compareWithList(expected);
+	}
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/ExternalCatalogITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/batch/ExternalCatalogITCase.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.scala.batch
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.api.scala.batch.utils.TableProgramsCollectionTestBase
+import org.apache.flink.table.api.scala.batch.utils.TableProgramsTestBase.TableConfigMode
+import org.apache.flink.table.catalog.TableIdentifier
+import org.apache.flink.table.utils.CommonTestData
+import org.apache.flink.test.util.TestBaseUtils
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import scala.collection.JavaConverters._
+
+@RunWith(classOf[Parameterized])
+class ExternalCatalogITCase(
+    configMode: TableConfigMode)
+    extends TableProgramsCollectionTestBase(configMode) {
+
+  @Test
+  def testSQL(): Unit = {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    tEnv.registerExternalCatalog("test", CommonTestData.getMockedFlinkExternalCatalog)
+    val sqlQuery = "SELECT * FROM test.db1.tb1 UNION ALL " +
+        "(SELECT d, e, g FROM test.db2.tb2 WHERE d < 3)"
+    val results = tEnv.sql(sqlQuery).collect()
+
+    val expected = Seq(
+      "1,1,Hi",
+      "2,2,Hello",
+      "3,2,Hello world",
+      "1,1,Hallo",
+      "2,2,Hallo Welt",
+      "2,3,Hallo Welt wie").mkString("\n")
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  @Test
+  def testTableAPI(): Unit = {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    tEnv.registerExternalCatalog("test", CommonTestData.getMockedFlinkExternalCatalog)
+    val table1 = tEnv.scan("test", new TableIdentifier("db1", "tb1"))
+    val table2 = tEnv.scan("test", new TableIdentifier("db2", "tb2"))
+    val results = table2.where("d < 3")
+        .select("d, e, g")
+        .unionAll(table1)
+        .collect()
+
+    val expected = Seq(
+      "1,1,Hi",
+      "2,2,Hello",
+      "3,2,Hello world",
+      "1,1,Hallo",
+      "2,2,Hallo Welt",
+      "2,3,Hallo Welt wie").mkString("\n")
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/ExternalCatalogITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/scala/stream/ExternalCatalogITCase.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.scala.stream
+
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase
+import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.api.scala.stream.utils.StreamITCase
+import org.apache.flink.table.utils.CommonTestData
+import org.apache.flink.types.Row
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.collection.mutable
+import org.apache.flink.table.api.scala._
+import org.apache.flink.api.scala._
+import org.apache.flink.table.catalog.TableIdentifier
+
+class ExternalCatalogITCase extends StreamingMultipleProgramsTestBase {
+
+  @Test
+  def testSQL(): Unit = {
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.clear
+
+    tEnv.registerExternalCatalog("test", CommonTestData.getMockedFlinkExternalCatalog)
+    val sqlQuery = "SELECT * FROM test.db1.tb1 UNION ALL " +
+        "(SELECT d, e, g FROM test.db2.tb2 WHERE d < 3)"
+    tEnv.sql(sqlQuery)
+        .toDataStream[Row]
+        .addSink(new StreamITCase.StringSink)
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "1,1,Hi",
+      "2,2,Hello",
+      "3,2,Hello world",
+      "1,1,Hallo",
+      "2,2,Hallo Welt",
+      "2,3,Hallo Welt wie")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testTableAPI(): Unit = {
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.clear
+
+    tEnv.registerExternalCatalog("test", CommonTestData.getMockedFlinkExternalCatalog)
+    val table1 = tEnv.scan("test", new TableIdentifier("db1", "tb1"))
+    val table2 = tEnv.scan("test", new TableIdentifier("db2", "tb2"))
+
+    table2.where("d < 3")
+        .select("d, e, g")
+        .unionAll(table1)
+        .toDataStream[Row]
+        .addSink(new StreamITCase.StringSink)
+
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "1,1,Hi",
+      "2,2,Hello",
+      "3,2,Hello world",
+      "1,1,Hallo",
+      "2,2,Hallo Welt",
+      "2,3,Hallo Welt wie"
+    )
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/catalog/ExternalCatalogSchemaTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/catalog/ExternalCatalogSchemaTest.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+import java.util.Collections
+
+import com.google.common.collect.Lists
+import org.apache.calcite.jdbc.CalciteSchema
+import org.apache.calcite.prepare.CalciteCatalogReader
+import org.apache.calcite.schema.SchemaPlus
+import org.apache.calcite.sql.validate.SqlMonikerType
+import org.apache.commons.collections.CollectionUtils
+import org.apache.flink.table.calcite.{FlinkTypeFactory, FlinkTypeSystem}
+import org.apache.flink.table.plan.schema.TableSourceTable
+import org.apache.flink.table.sources.CsvTableSource
+import org.apache.flink.table.utils.CommonTestData
+import org.junit.{Before, Test}
+import org.junit.Assert._
+
+class ExternalCatalogSchemaTest {
+
+  private val schemaName: String = "test"
+  private var externalCatalogSchema: ExternalCatalogSchema = _
+  private var calciteCatalogReader: CalciteCatalogReader = _
+  private val db = "db1"
+  private val tb = "tb1"
+
+  @Before
+  def setUp(): Unit = {
+    val rootSchemaPlus: SchemaPlus = CalciteSchema.createRootSchema(true, false).plus()
+    val catalog = CommonTestData.getMockedFlinkExternalCatalog
+    externalCatalogSchema = ExternalCatalogSchema.create(rootSchemaPlus, schemaName, catalog)
+    val typeFactory = new FlinkTypeFactory(new FlinkTypeSystem())
+    calciteCatalogReader = new CalciteCatalogReader(
+      CalciteSchema.from(rootSchemaPlus),
+      false,
+      Collections.emptyList(),
+      typeFactory)
+  }
+
+  @Test
+  def testGetSubSchema(): Unit = {
+    val allSchemaObjectNames = calciteCatalogReader
+        .getAllSchemaObjectNames(Lists.newArrayList(schemaName))
+    assertTrue(allSchemaObjectNames.size() == 2)
+    assertEquals(SqlMonikerType.SCHEMA, allSchemaObjectNames.get(0).getType)
+    assertTrue(
+      CollectionUtils.isEqualCollection(
+        allSchemaObjectNames.get(0).getFullyQualifiedNames,
+        Lists.newArrayList(schemaName, db)
+      ))
+  }
+
+  @Test
+  def testGetTable(): Unit = {
+    val relOptTable = calciteCatalogReader.getTable(Lists.newArrayList(schemaName, db, tb))
+    assertNotNull(relOptTable)
+    val tableSourceTable = relOptTable.unwrap(classOf[TableSourceTable[_]])
+    tableSourceTable match {
+      case tst: TableSourceTable[_] =>
+        assertTrue(tst.tableSource.isInstanceOf[CsvTableSource])
+      case _ =>
+        fail("unexpected table type!")
+    }
+  }
+
+  @Test
+  def testGetNotExistTable(): Unit = {
+    val relOptTable = calciteCatalogReader.getTable(
+      Lists.newArrayList(schemaName, db, "nonexist-tb"))
+    assertNull(relOptTable)
+  }
+
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/catalog/InMemoryExternalCatalogTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/catalog/InMemoryExternalCatalogTest.scala
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo
+import org.apache.flink.table.api.{DatabaseAlreadyExistException, DatabaseNotExistException, TableAlreadyExistException, TableNotExistException}
+import org.junit.{Before, Test}
+import org.junit.Assert._
+
+class InMemoryExternalCatalogTest {
+
+  private val databaseName = "db1"
+
+  private var catalog: InMemoryExternalCatalog = _
+
+  @Before
+  def setUp(): Unit = {
+    catalog = new InMemoryExternalCatalog()
+    catalog.createDatabase(ExternalCatalogDatabase(databaseName), ignoreIfExists = false)
+  }
+
+  @Test
+  def testCreateTable(): Unit = {
+    assertTrue(catalog.listTables(databaseName).isEmpty)
+    catalog.createTable(createTableInstance(databaseName, "t1"), ignoreIfExists = false)
+    assertTrue(catalog.listTables(databaseName).toSet == Set("t1"))
+  }
+
+  @Test(expected = classOf[TableAlreadyExistException])
+  def testCreateExistedTable(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(createTableInstance(databaseName, tableName), false)
+    catalog.createTable(createTableInstance(databaseName, tableName), false)
+  }
+
+  @Test
+  def testGetTable(): Unit = {
+    val originTable = createTableInstance(databaseName, "t1")
+    catalog.createTable(originTable, false)
+    assertEquals(catalog.getTable(databaseName, "t1"), originTable)
+  }
+
+  @Test(expected = classOf[DatabaseNotExistException])
+  def testGetTableUnderNotExistDatabaseName(): Unit = {
+    catalog.getTable("notexistedDb", "t1")
+  }
+
+  @Test(expected = classOf[TableNotExistException])
+  def testGetNotExistTable(): Unit = {
+    catalog.getTable(databaseName, "t1")
+  }
+
+  @Test
+  def testAlterTable(): Unit = {
+    val tableName = "t1"
+    val table = createTableInstance(databaseName, tableName)
+    catalog.createTable(table, false)
+    assertEquals(catalog.getTable(databaseName, tableName), table)
+    val newTable = createTableInstance(databaseName, tableName)
+    catalog.alterTable(newTable)
+    val currentTable = catalog.getTable(databaseName, tableName)
+    // validate the table is really replaced after alter table
+    assertNotEquals(table, currentTable)
+    assertEquals(newTable, currentTable)
+  }
+
+  @Test(expected = classOf[TableNotExistException])
+  def testAlterNotExistTable(): Unit = {
+    catalog.alterTable(createTableInstance(databaseName, "t1"))
+  }
+
+  @Test
+  def testDropTable(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(createTableInstance(databaseName, tableName), false)
+    assertTrue(catalog.listTables(databaseName).contains(tableName))
+    catalog.dropTable(databaseName, tableName, false)
+    assertFalse(catalog.listTables(databaseName).contains(tableName))
+  }
+
+  @Test(expected = classOf[TableNotExistException])
+  def testDropNotExistTable(): Unit = {
+    catalog.dropTable(databaseName, "t1", false)
+  }
+
+  @Test
+  def testListDatabases(): Unit = {
+    assertTrue(catalog.listDatabases().toSet == Set(databaseName))
+  }
+
+  @Test
+  def testGetDatabase(): Unit = {
+    assertNotNull(catalog.getDatabase(databaseName))
+  }
+
+  @Test
+  def testGetNotExistDatabase(): Unit = {
+    assertNull(catalog.getDatabase("notexistedDb"))
+  }
+
+  @Test
+  def testCreateDatabase(): Unit = {
+    val originDatabasesNum = catalog.listDatabases().size
+    catalog.createDatabase(ExternalCatalogDatabase("db2"), false)
+    assertEquals(catalog.listDatabases().size, originDatabasesNum + 1)
+  }
+
+  @Test(expected = classOf[DatabaseAlreadyExistException])
+  def testCreateExistedDatabase(): Unit = {
+    catalog.createDatabase(ExternalCatalogDatabase(databaseName), false)
+  }
+
+  private def createTableInstance(dbName: String, tableName: String): ExternalCatalogTable = {
+    val schema = new DataSchema(
+      Array(
+        BasicTypeInfo.STRING_TYPE_INFO,
+        BasicTypeInfo.INT_TYPE_INFO
+      ),
+      Array("first", "second"))
+    ExternalCatalogTable(
+      TableIdentifier(dbName, tableName),
+      "csv",
+      schema)
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/catalog/InMemoryExternalCatalogTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/catalog/InMemoryExternalCatalogTest.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.catalog
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo
-import org.apache.flink.table.api.{DatabaseAlreadyExistException, DatabaseNotExistException, TableAlreadyExistException, TableNotExistException}
+import org.apache.flink.table.api._
 import org.junit.{Before, Test}
 import org.junit.Assert._
 
@@ -36,24 +36,172 @@ class InMemoryExternalCatalogTest {
   }
 
   @Test
+  def testCreatePartition(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    assertTrue(catalog.listPartitionSpec(databaseName, tableName).isEmpty)
+    val newPartitionSpec = Map("hour"->"12", "ds"->"2016-02-01")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    catalog.createPartition(databaseName, tableName, newPartition, false)
+    assertTrue(catalog.listPartitionSpec(databaseName, tableName).toSet == Set(newPartitionSpec))
+  }
+
+  @Test(expected = classOf[UnsupportedOperationException])
+  def testCreatePartitionOnUnPartitionedTable(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createNonPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    val newPartitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    catalog.createPartition(databaseName, tableName, newPartition, false)
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testCreateInvalidPartitionSpec(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    val newPartitionSpec = Map("ds"->"2016-02-01", "h"->"12")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    catalog.createPartition(databaseName, tableName, newPartition, false)
+  }
+
+  @Test(expected = classOf[PartitionAlreadyExistException])
+  def testCreateExistedPartition(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    val newPartitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    catalog.createPartition(databaseName, tableName, newPartition, false)
+    val newPartitionSpec1 = Map("hour"->"12", "ds"->"2016-02-01")
+    val newPartition1 = ExternalCatalogTablePartition(newPartitionSpec1)
+    catalog.createPartition(databaseName, tableName, newPartition1, false)
+  }
+
+  @Test(expected = classOf[TableNotExistException])
+  def testCreatePartitionOnNotExistTable(): Unit = {
+    val newPartitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    catalog.createPartition(databaseName, "notexistedTb", newPartition, false)
+  }
+
+  @Test(expected = classOf[DatabaseNotExistException])
+  def testCreatePartitionOnNotExistDatabase(): Unit = {
+    val tableName = "t1"
+    val newPartitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    catalog.createPartition("notexistedDb", tableName, newPartition, false)
+  }
+
+  @Test
+  def testGetPartition(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    val newPartitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    catalog.createPartition(databaseName, tableName, newPartition, false)
+    assertEquals(catalog.getPartition(databaseName, tableName, newPartitionSpec), newPartition)
+  }
+
+  @Test(expected = classOf[PartitionNotExistException])
+  def testGetNotExistPartition(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    val newPartitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    assertEquals(catalog.getPartition(databaseName, tableName, newPartitionSpec), newPartition)
+  }
+
+  @Test
+  def testDropPartition(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    val newPartitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    catalog.createPartition(databaseName, tableName, newPartition, false)
+    assertTrue(catalog.listPartitionSpec(databaseName, tableName).contains(newPartitionSpec))
+    catalog.dropPartition(databaseName, tableName, newPartitionSpec, false)
+    assertFalse(catalog.listPartitionSpec(databaseName, tableName).contains(newPartitionSpec))
+  }
+
+  @Test(expected = classOf[PartitionNotExistException])
+  def testDropNotExistPartition(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    val partitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    catalog.dropPartition(databaseName, tableName, partitionSpec, false)
+  }
+
+  @Test
+  def testListPartitionSpec(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    assertTrue(catalog.listPartitionSpec(databaseName, tableName).isEmpty)
+    val newPartitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    val newPartition = ExternalCatalogTablePartition(newPartitionSpec)
+    catalog.createPartition(databaseName, tableName, newPartition, false)
+    assertEquals(catalog.listPartitionSpec(databaseName, tableName), Seq(newPartitionSpec))
+  }
+
+  @Test
+  def testAlterPartition(): Unit = {
+    val tableName = "t1"
+    catalog.createTable(
+      createPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    val newPartitionSpec = Map("ds"->"2016-02-01", "hour"->"12")
+    val newPartition = ExternalCatalogTablePartition(
+      newPartitionSpec,
+      properties = Map("location" -> "/tmp/ds=2016-02-01/hour=12"))
+    catalog.createPartition(databaseName, tableName, newPartition, false)
+    val updatedPartition = ExternalCatalogTablePartition(
+      newPartitionSpec,
+      properties = Map("location" -> "/tmp1/ds=2016-02-01/hour=12"))
+    catalog.alterPartition(databaseName, tableName, updatedPartition)
+    val currentPartition = catalog.getPartition(databaseName, tableName, newPartitionSpec)
+    assertEquals(currentPartition, updatedPartition)
+    assertNotEquals(currentPartition, newPartition)
+  }
+
+  @Test
   def testCreateTable(): Unit = {
     assertTrue(catalog.listTables(databaseName).isEmpty)
-    catalog.createTable(createTableInstance(databaseName, "t1"), ignoreIfExists = false)
-    assertTrue(catalog.listTables(databaseName).toSet == Set("t1"))
+    val tableName = "t1"
+    catalog.createTable(
+      createNonPartitionedTableInstance(databaseName, tableName),
+      ignoreIfExists = false)
+    assertTrue(catalog.listTables(databaseName).toSet == Set(tableName))
   }
 
   @Test(expected = classOf[TableAlreadyExistException])
   def testCreateExistedTable(): Unit = {
     val tableName = "t1"
-    catalog.createTable(createTableInstance(databaseName, tableName), false)
-    catalog.createTable(createTableInstance(databaseName, tableName), false)
+    catalog.createTable(createNonPartitionedTableInstance(databaseName, tableName), false)
+    catalog.createTable(createNonPartitionedTableInstance(databaseName, tableName), false)
   }
 
   @Test
   def testGetTable(): Unit = {
-    val originTable = createTableInstance(databaseName, "t1")
+    val tableName = "t1"
+    val originTable = createNonPartitionedTableInstance(databaseName, tableName)
     catalog.createTable(originTable, false)
-    assertEquals(catalog.getTable(databaseName, "t1"), originTable)
+    assertEquals(catalog.getTable(databaseName, tableName), originTable)
   }
 
   @Test(expected = classOf[DatabaseNotExistException])
@@ -69,10 +217,10 @@ class InMemoryExternalCatalogTest {
   @Test
   def testAlterTable(): Unit = {
     val tableName = "t1"
-    val table = createTableInstance(databaseName, tableName)
+    val table = createNonPartitionedTableInstance(databaseName, tableName)
     catalog.createTable(table, false)
     assertEquals(catalog.getTable(databaseName, tableName), table)
-    val newTable = createTableInstance(databaseName, tableName)
+    val newTable = createNonPartitionedTableInstance(databaseName, tableName)
     catalog.alterTable(newTable)
     val currentTable = catalog.getTable(databaseName, tableName)
     // validate the table is really replaced after alter table
@@ -82,13 +230,13 @@ class InMemoryExternalCatalogTest {
 
   @Test(expected = classOf[TableNotExistException])
   def testAlterNotExistTable(): Unit = {
-    catalog.alterTable(createTableInstance(databaseName, "t1"))
+    catalog.alterTable(createNonPartitionedTableInstance(databaseName, "t1"))
   }
 
   @Test
   def testDropTable(): Unit = {
     val tableName = "t1"
-    catalog.createTable(createTableInstance(databaseName, tableName), false)
+    catalog.createTable(createNonPartitionedTableInstance(databaseName, tableName), false)
     assertTrue(catalog.listTables(databaseName).contains(tableName))
     catalog.dropTable(databaseName, tableName, false)
     assertFalse(catalog.listTables(databaseName).contains(tableName))
@@ -126,7 +274,9 @@ class InMemoryExternalCatalogTest {
     catalog.createDatabase(ExternalCatalogDatabase(databaseName), false)
   }
 
-  private def createTableInstance(dbName: String, tableName: String): ExternalCatalogTable = {
+  private def createNonPartitionedTableInstance(
+      dbName: String,
+      tableName: String): ExternalCatalogTable = {
     val schema = new DataSchema(
       Array(
         BasicTypeInfo.STRING_TYPE_INFO,
@@ -138,4 +288,23 @@ class InMemoryExternalCatalogTest {
       "csv",
       schema)
   }
+
+  private def createPartitionedTableInstance(
+      dbName: String,
+      tableName: String): ExternalCatalogTable = {
+    val schema = new DataSchema(
+      Array(
+        BasicTypeInfo.STRING_TYPE_INFO,
+        BasicTypeInfo.INT_TYPE_INFO
+      ),
+      Array("first", "second"))
+    ExternalCatalogTable(
+      TableIdentifier(dbName, tableName),
+      "hive",
+      schema,
+      partitionColumnNames = Array("ds","hour"),
+      isPartitioned = true
+    )
+  }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@ under the License.
 		<module>flink-metrics</module>
 		<module>flink-yarn</module>
 		<module>flink-fs-tests</module>
+		<module>blink</module>
 	</modules>
 
 	<properties>


### PR DESCRIPTION
提供odps externalCatalog的实现：
这个pr分为5个commit，每个commit各自的功能为：
1. [flink-5568] [Table API & SQL]Introduce interface for catalog, and provide an in-memory implementation. Integrate external catalog with calcite catalog，对应pr：https://github.com/beyond1920/flink/pull/2
2. [flink-5570] [Table API & SQL]Support register external catalog to table environment. 对应的pr：
https://github.com/beyond1920/flink/pull/3
3. 给ExternalCatalog增加partition的概念，对应的pr：https://github.com/beyond1920/flink/pull/5
4. 将blink的odps connector移到flink module下，基于flink－table最新的代码做调整
5. 加上odps externalCatalog实现
前4个commit都是前置的，review当前pr只需要关注第5个commit即可。